### PR TITLE
chore: fix env name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     # Template instruction: Replace <repository name> and delete this comment
-    environment: npmjs:@cap-js/<repository name>
+    environment: npmjs:@cap-js/mcp
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
### Fix NPM Publish Environment Name in Release Workflow

Replaces the placeholder `<repository name>` in the GitHub Actions release workflow with the correct environment name `npmjs:@cap-js/mcp` for the `publish-npm` job.

**Change type:** 🐛 Bug Fix

**What changed:**
- In `.github/workflows/release.yml`, the `environment` field under the `publish-npm` job was updated from the template placeholder `npmjs:@cap-js/<repository name>` to the correct value `npmjs:@cap-js/mcp`.

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.14` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Correlation ID: `4fd28f70-76ba-11f1-9095-df5822b1b5c7`
- File Content Strategy: Full file content
- Output Template: Repository PR Template
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
