### PR TITLE
chore: update release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.x, 22.x]
-        cds-version: [latest, 8]
+        cds-version: [latest]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
### chore: Simplify Release Workflow CDS Version Matrix

**Category:** Chore

Updates the GitHub Actions release workflow to streamline the test matrix by removing the older CDS version (`8`) from the test run, keeping only `latest`.

**Changes:**
- In `.github/workflows/release.yml`, the `cds-version` matrix entry is reduced from `[latest, 8]` to `[latest]`, halving the number of matrix job combinations run during the release workflow.

This reduces CI overhead by no longer testing against CDS version `8` during releases.

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.14`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `e95643e0-76e1-11f1-8560-3ba15bbf645d`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
</details>
