### PR TITLE
chore: bump node version in rel workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
         cds-version: [latest]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
### Bump Node.js versions in release workflow

Updates the Node.js version matrix in the release workflow, replacing `20.x` with `24.x` to test against more current and supported versions.

**Change:** `.github/workflows/release.yml`
- Updated `node-version` matrix from `[20.x, 22.x]` to `[22.x, 24.x]`

### Category: `Chore`

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.2`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `298b0910-7aab-11f1-8722-0cf303137459`
- File Content Strategy: Full file content
</details>
