### PR TITLE
chore: prep v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.2.0 - Unreleased
+## Version 1.2.0 - 2026-07-21
+
+### Added
+
+- Experimental SQL input for the `query` tool
 
 ## Version 1.1.1 - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ All configuration lives under `cds.mcp` in your `package.json`:
 }
 ```
 
-| Flag              | Default | Description                                                                                                                                                        |
-| ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `per_action_tool` | `false`   | Expose each action/function as its own dedicated tool instead of the generic `call_action` tool.                                                                   |
-| `toon_format`     | `true`    | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                        |
-| `prefix`          | `false`   | Prefix tool names with the slugified service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`). |
-| `format`          | `"cql"`   | Experimental: Change the `query` input format. `"cql"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
+| Flag              | Default | Description                                                                                                                                                            |
+| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call_action` tool.                                                                       |
+| `toon_format`     | `true`  | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                            |
+| `prefix`          | `false` | Prefix tool names with the slugified service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`).     |
+| `format`          | `"cql"` | Experimental: Change the `query` input format. `"cql"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
 
 For all other configuration options, refer to the official [documentation](https://cap.cloud.sap/docs/guides/protocols/mcp).
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All configuration lives under `cds.mcp` in your `package.json`:
 | `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call_action` tool.                                                                       |
 | `toon_format`     | `true`  | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                            |
 | `prefix`          | `false` | Prefix tool names with the slugified service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`).     |
-| `format`          | `"cql"` | Experimental: Change the `query` input format. `"cql"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
+| `format`          | `"cqn"` | Experimental: Change the `query` input format. `"cqn"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
 
 For all other configuration options, refer to the official [documentation](https://cap.cloud.sap/docs/guides/protocols/mcp).
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All configuration lives under `cds.mcp` in your `package.json`:
 | `per_action_tool` | `false`   | Expose each action/function as its own dedicated tool instead of the generic `call_action` tool.                                                                   |
 | `toon_format`     | `true`    | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                        |
 | `prefix`          | `false`   | Prefix tool names with the slugified service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`). |
-| `format`          | `"cql"`   | Query input format. `"cql"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
+| `format`          | `"cql"`   | Experimental: Change the `query` input format. `"cql"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
 
 For all other configuration options, refer to the official [documentation](https://cap.cloud.sap/docs/guides/protocols/mcp).
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ All configuration lives under `cds.mcp` in your `package.json`:
 
 | Flag              | Default | Description                                                                                                                                                        |
 | ----------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call_action` tool.                                                                   |
-| `toon_format`     | `true`  | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                        |
-| `prefix`          | `false` | Prefix tool names with the slugified service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`). |
+| `per_action_tool` | `false`   | Expose each action/function as its own dedicated tool instead of the generic `call_action` tool.                                                                   |
+| `toon_format`     | `true`    | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                        |
+| `prefix`          | `false`   | Prefix tool names with the slugified service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`). |
+| `format`          | `"cql"`   | Query input format. `"cql"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
 
 For all other configuration options, refer to the official [documentation](https://cap.cloud.sap/docs/guides/protocols/mcp).
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -129,7 +129,7 @@ function createGenericReadToolDefinition(entityNames, serviceName, prefix) {
   if (cds.env.mcp?.format === 'sql') {
     return {
       name,
-      description: `Execute a SQL SELECT query against ${serviceName} service. Use describe to discover available entities and their fields (returned as CDS definitions). Only SELECT statements are allowed; LIMIT is auto-clamped to the service max. Only the following standard functions and aggregates are allowed: (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). Database system functions are rejected.`,
+      description: `Execute a SQL SELECT query against ${serviceName} service. Use describe to discover available entities and their fields (returned as CDS definitions). Only SELECT statements are allowed; LIMIT is auto-clamped to the service max. Only standard CAP/OData functions and aggregates are permitted (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). Database system functions like CURRENT_USER, SESSION_USER, SYSUUID, and pseudo-columns like CURRENT_SCHEMA are rejected.`,
       inputSchema: z.object({
         sql: z
           .string()

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -129,7 +129,7 @@ function createGenericReadToolDefinition(entityNames, serviceName, prefix) {
   if (cds.env.mcp?.format === 'sql') {
     return {
       name,
-      description: `Execute a SQL SELECT query against ${serviceName} service. Use describe to discover available entities and their fields (returned as CDS definitions). Only SELECT statements are allowed; LIMIT is auto-clamped to the service max. Only the following standard functions are allowed: (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). Database system functions are rejected.`,
+      description: `Execute a SQL SELECT query against ${serviceName} service. Use describe to discover available entities and their fields (returned as CDS definitions). Only SELECT statements are allowed; LIMIT is auto-clamped to the service max. Only the following standard functions and aggregates are allowed: (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). Database system functions are rejected.`,
       inputSchema: z.object({
         sql: z
           .string()

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -129,7 +129,7 @@ function createGenericReadToolDefinition(entityNames, serviceName, prefix) {
   if (cds.env.mcp?.format === 'sql') {
     return {
       name,
-      description: `Execute a SQL SELECT query against ${serviceName} service. Use describe to discover available entities and their fields (returned as CDS definitions). Only SELECT statements are allowed; LIMIT is auto-clamped to the service max. Only standard CAP/OData functions and aggregates are permitted (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). Database system functions like CURRENT_USER, SESSION_USER, SYSUUID, and pseudo-columns like CURRENT_SCHEMA are rejected.`,
+      description: `Execute a SQL SELECT query against ${serviceName} service. Use describe to discover available entities and their fields (returned as CDS definitions). Only SELECT statements are allowed; LIMIT is auto-clamped to the service max. Only the following standard functions are allowed: (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). Database system functions are rejected.`,
       inputSchema: z.object({
         sql: z
           .string()

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -29,7 +29,8 @@
     "mcp": {
       "per_action_tool": false,
       "toon_format": true,
-      "prefix": false
+      "prefix": false,
+      "format": "cql"
     },
     "hana": {
       "fuzzy": false

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -30,7 +30,7 @@
       "per_action_tool": false,
       "toon_format": true,
       "prefix": false,
-      "format": "cql"
+      "format": "cqn"
     },
     "hana": {
       "fuzzy": false


### PR DESCRIPTION
## chore: Prep v1.2.0

This PR prepares the `v1.2.0` release by finalizing the changelog, updating documentation, and making minor refinements.

### Changes

**📋 CHANGELOG.md**
- Marks `Version 1.2.0` with the release date `2026-07-21` (previously "Unreleased")
- Adds changelog entry for the experimental SQL input feature in the `query` tool

**📖 README.md**
- Adds documentation for the new `format` configuration option (`"cql"` | `"sql"`), which controls whether the `query` tool accepts structured CQN input or a plain SQL `SELECT` statement
- Minor formatting alignment in the configuration table

**⚙️ lib/tools.js**
- Cleans up the SQL tool description to be more concise and clear, removing references to specific rejected database system functions in favor of a general statement

**🧪 tests/bookshop/package.json**
- Adds `"format": "cql"` to the test bookshop MCP configuration to explicitly set the default query format

### Have you...

- [x] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.2`

- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `ffca8fa0-84dd-11f1-86c3-a347cb278dc5`
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
</details>
