### PR TITLE
chore: update toon dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@toon-format/toon": "^2.3.0",
+    "@toon-format/toon": ">=2.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/bookshop-mtx/package.json
+++ b/tests/bookshop-mtx/package.json
@@ -8,7 +8,6 @@
     "@sap/cds": ">=9",
     "@sap/cds-mtxs": ">=3",
     "@sap/xssec": "^4",
-    "@toon-format/toon": "^2.3.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/bookshop/package.json
+++ b/tests/bookshop/package.json
@@ -8,7 +8,6 @@
     "@sap/cds": ">=9",
     "@sap/hana-client": "^2.29.23",
     "@sap/xssec": "^4",
-    "@toon-format/toon": "^2.3.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
cap/agents accepts >=0, hence latest v4, cap/mcp only ^2.3?