### PR TITLE
Rename `call_action` to `call` + revise `cds.mcp.prefix` impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 1.3.0 - Unreleased
+
+### Fixed
+
+- Optional tool name prefix now uses the full service name for uniqueness
+
+### Changed
+
+- Renamed the `call_action` tool to `call`
+
 ## Version 1.2.0 - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,12 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.3.0 - Unreleased
-
-### Fixed
-
-- Optional tool name prefix now uses the full service name for uniqueness
+## Version 1.3.0 - TBD
 
 ### Changed
 
 - Renamed the `call_action` tool to `call`
+- `cds.mcp.prefix` now creates a prefix from the full service name
 
 ## Version 1.2.0 - 2026-07-21
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ All configuration lives under `cds.mcp` in your `package.json`:
 ```
 
 | Flag              | Default | Description                                                                                                                                                            |
-| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call_action` tool.                                                                       |
+|-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call` action tool.                                                                       |
 | `toon_format`     | `true`  | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                            |
 | `prefix`          | `false` | Prefix tool names with the slugified service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`).     |
 | `format`          | `"cqn"` | Experimental: Change the `query` input format. `"cqn"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All configuration lives under `cds.mcp` in your `package.json`:
 |-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call` action tool.                                                                       |
 | `toon_format`     | `true`  | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                            |
-| `prefix`          | `false` | Prefix tool names with the slugified service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`).     |
+| `prefix`          | `false` | Prefix tool names with the service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`).     |
 | `format`          | `"cqn"` | Experimental: Change the `query` input format. `"cqn"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
 
 For all other configuration options, refer to the official [documentation](https://cap.cloud.sap/docs/guides/protocols/mcp).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All configuration lives under `cds.mcp` in your `package.json`:
 | ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call` action tool.                                                                       |
 | `toon_format`     | `true`  | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                            |
-| `prefix`          | `false` | Prefix tool names with the service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `CatalogService-query`, `AdminService-query`).               |
+| `prefix`          | `false` | Prefix tool names with the service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `CatalogService-query`, `AdminService-query`).    |
 | `format`          | `"cqn"` | Experimental: Change the `query` input format. `"cqn"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
 
 For all other configuration options, refer to the official [documentation](https://cap.cloud.sap/docs/guides/protocols/mcp).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All configuration lives under `cds.mcp` in your `package.json`:
 | ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call` action tool.                                                                       |
 | `toon_format`     | `true`  | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                            |
-| `prefix`          | `false` | Prefix tool names with the service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`).               |
+| `prefix`          | `false` | Prefix tool names with the service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `CatalogService-query`, `AdminService-query`).               |
 | `format`          | `"cqn"` | Experimental: Change the `query` input format. `"cqn"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
 
 For all other configuration options, refer to the official [documentation](https://cap.cloud.sap/docs/guides/protocols/mcp).

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ All configuration lives under `cds.mcp` in your `package.json`:
 ```
 
 | Flag              | Default | Description                                                                                                                                                            |
-|-------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `per_action_tool` | `false` | Expose each action/function as its own dedicated tool instead of the generic `call` action tool.                                                                       |
 | `toon_format`     | `true`  | Return query results in [TOON](https://www.npmjs.com/package/@toon-format/toon) format. Set to `false` to use JSON instead.                                            |
-| `prefix`          | `false` | Prefix tool names with the service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`).     |
+| `prefix`          | `false` | Prefix tool names with the service name to avoid collisions when a MCP client connects to multiple MCP servers (e.g. `catalog_query`, `admin_describe`).               |
 | `format`          | `"cqn"` | Experimental: Change the `query` input format. `"cqn"` (default) uses structured CQN input. `"sql"` switches the `query` tool to accept a plain SQL `SELECT` statement |
 
 For all other configuration options, refer to the official [documentation](https://cap.cloud.sap/docs/guides/protocols/mcp).

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -87,7 +87,7 @@ function generateToolsForService(def, model) {
         })
       }
     } else {
-      // Register generic call_action tool
+      // Register generic call action tool
       const actionDef = createCallActionToolDefinition(actionNames, def.name, prefix)
       tools.push({
         name: actionDef.name,

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -105,7 +105,7 @@ function generateToolsForService(def, model) {
 }
 
 function _compileService(def, model, options) {
-  // Build service path - respect @path annotation, otherwise use slugified name
+  // Build service path - respect @path annotation, otherwise use name
   // Strip leading slash from @path if present
   const customPath = def['@path']
   const servicePath = customPath ? customPath.replace(/^\//, '') : slugified(def.name)

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,10 @@ const {
   registerDescribeTool,
   getInstructions
 } = require('./tools')
+
+const registerActionTool = cds.env.mcp?.per_action_tool
+  ? registerPerActionTools
+  : registerCallActionTool
 const { getDescription } = require('./utils/cds-to-schema')
 const { checkAuthorization } = require('./auth')
 const { resolvePrefix } = require('./utils/service-name')
@@ -64,12 +68,9 @@ module.exports = function McpProtocolAdapter(srv) {
       const entityCount = Object.keys(entities).length
       const actionCount = Object.keys(actions).length
       if (entityCount > 0 || actionCount > 0) {
-        registerGenericReadTool(server, srv, entities, prefix)
-        const registerActionTool = cds.env.mcp?.per_action_tool
-          ? registerPerActionTools
-          : registerCallActionTool
-        registerActionTool(server, srv, actions, prefix)
         registerDescribeTool(server, srv, entities, actions, prefix)
+        registerGenericReadTool(server, srv, entities, prefix)
+        registerActionTool(server, srv, actions, prefix)
       } else {
         // No accessible entities - register empty tools capability
         server.server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }))

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -49,7 +49,10 @@ const LOCALIZED_ELEMENTS = ['localized', 'texts']
 function getInstructions(def, locale, prefix_) {
   locale = locale || cds.context?.locale || 'en'
   const custom = resolveI18n(def['@mcp.instructions'], locale)
-  return custom || `Use the \`${prefix_}describe\` tool to explore the data model and available actions/functions. Then use \`${prefix_}query\` to read data or \`${prefix_}call\` to invoke actions or functions.`
+  return (
+    custom ||
+    `Use the \`${prefix_}describe\` tool to explore the data model and available actions/functions. Then use \`${prefix_}query\` to read data or \`${prefix_}call\` to invoke actions or functions.`
+  )
 }
 
 // Create MCP error response

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -47,14 +47,14 @@ const DRAFT_ELEMENTS = [
 const LOCALIZED_ELEMENTS = ['localized', 'texts']
 
 const DEFAULT_INSTRUCTIONS =
-  "Use the 'describe' tool to explore the data model and available actions/functions. Then use 'query' to read data or 'call_action' to invoke actions or functions."
+  "Use the `describe` tool to explore the data model and available actions/functions. Then use `query` to read data or `call` to invoke actions or functions."
 
 function getInstructions(def, locale, prefix) {
   locale = locale || cds.context?.locale || 'en'
   const custom = resolveI18n(def['@mcp.instructions'], locale)
   if (custom) return custom
   if (!prefix) return DEFAULT_INSTRUCTIONS
-  return `Use the '${prefix}_describe' tool to explore the data model and available actions/functions. Then use '${prefix}_query' to read data or '${prefix}_call_action' to invoke actions or functions.`
+  return `Use the '${prefix}_describe' tool to explore the data model and available actions/functions. Then use '${prefix}_query' to read data or '${prefix}_call' to invoke actions or functions.`
 }
 
 // Create MCP error response
@@ -191,7 +191,7 @@ function createDescribeToolDefinition(entityNames, actionNames, serviceName, pre
 }
 
 function createCallActionToolDefinition(actionNames, serviceName, prefix) {
-  const name = prefix ? `${prefix}_call_action` : 'call_action'
+  const name = prefix ? `${prefix}_call` : 'call'
   return {
     name,
     description: `Call an unbound action or function in ${serviceName} service. Use describe to discover available actions and their parameters.`,
@@ -252,7 +252,7 @@ function registerDescribeTool(server, srv, entities, actions = {}, prefix, { log
   log.debug('Registered tool', { tool: def.name, service: srv.name })
 }
 
-// Register the call_action tool for invoking unbound actions/functions
+// Register the call action tool for invoking unbound actions/functions
 function registerCallActionTool(server, srv, actions, prefix, { log = LOG } = {}) {
   const actionNames = Object.keys(actions)
   if (actionNames.length === 0) return // No actions to register
@@ -879,7 +879,7 @@ function _stripAnnotations(obj) {
 async function executeCallActionTool(srv, actions, args, { log = LOG } = {}) {
   const { action: actionName, parameters = {} } = args
   log(
-    'call_action',
+    'call',
     fmt({ service: srv.name, action: actionName, parameters: buildQueryArgs(parameters) })
   )
 
@@ -909,7 +909,7 @@ async function executeCallActionTool(srv, actions, args, { log = LOG } = {}) {
       structuredContent: structured
     }
   } catch (err) {
-    log.error('Action execution failed', { action: actionName, error: formatError(err) })
+    log.error(`Executing action '${actionName}' failed with: \n\n`, err)
 
     // Handle authorization errors
     if (err.code === 401 || err.code === 403) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -393,7 +393,7 @@ async function executePerActionTool(srv, actionName, action, args, { log = LOG }
       structuredContent: structured
     }
   } catch (err) {
-    log.error('Action execution failed', { action: actionName, error: formatError(err) })
+    log.error(`Executing action '${actionName}' failed with: \n\n`, err)
 
     if (err.code === 401 || err.code === 403) {
       return errorResponse(

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -46,15 +46,10 @@ const DRAFT_ELEMENTS = [
 
 const LOCALIZED_ELEMENTS = ['localized', 'texts']
 
-const DEFAULT_INSTRUCTIONS =
-  "Use the `describe` tool to explore the data model and available actions/functions. Then use `query` to read data or `call` to invoke actions or functions."
-
-function getInstructions(def, locale, prefix) {
+function getInstructions(def, locale, prefix_) {
   locale = locale || cds.context?.locale || 'en'
   const custom = resolveI18n(def['@mcp.instructions'], locale)
-  if (custom) return custom
-  if (!prefix) return DEFAULT_INSTRUCTIONS
-  return `Use the '${prefix}_describe' tool to explore the data model and available actions/functions. Then use '${prefix}_query' to read data or '${prefix}_call' to invoke actions or functions.`
+  return custom || `Use the \`${prefix_}describe\` tool to explore the data model and available actions/functions. Then use \`${prefix_}query\` to read data or \`${prefix_}call\` to invoke actions or functions.`
 }
 
 // Create MCP error response
@@ -125,7 +120,7 @@ function validateFields(fields, entity, definitions) {
 }
 
 function createGenericReadToolDefinition(entityNames, serviceName, prefix) {
-  const name = prefix ? `${prefix}_query` : 'query'
+  const name = prefix + 'query'
   if (cds.env.mcp?.format === 'sql') {
     return {
       name,
@@ -174,7 +169,7 @@ function createDescribeToolDefinition(entityNames, actionNames, serviceName, pre
       .describe('Specific actions or functions to get parameter details for.')
   }
 
-  const name = prefix ? `${prefix}_describe` : 'describe'
+  const name = prefix + 'describe'
   return {
     name,
     description:
@@ -191,7 +186,7 @@ function createDescribeToolDefinition(entityNames, actionNames, serviceName, pre
 }
 
 function createCallActionToolDefinition(actionNames, serviceName, prefix) {
-  const name = prefix ? `${prefix}_call` : 'call'
+  const name = prefix + 'call'
   return {
     name,
     description: `Call an unbound action or function in ${serviceName} service. Use describe to discover available actions and their parameters.`,
@@ -335,7 +330,7 @@ function createPerActionToolDefinition(actionName, action, serviceName, model, p
     description += `. Returns: ${returnsInfo}`
   }
 
-  const name = prefix ? `${prefix}_${actionName}` : actionName
+  const name = prefix + actionName
   return {
     name,
     description,

--- a/lib/utils/service-name.js
+++ b/lib/utils/service-name.js
@@ -2,10 +2,11 @@ const cds = require('@sap/cds')
 
 const PREFIX = cds.env.mcp?.prefix === true
 
-exports.resolvePrefix =
-  !PREFIX ? () => '' :
-  PREFIX === true ? (d) => d.name + '-' :
-  (d,prefix) => prefix.replace(/\{service.name\}/, d.name)
+exports.resolvePrefix = !PREFIX
+  ? () => ''
+  : PREFIX === true
+    ? (d) => d.name + '-'
+    : (d, prefix) => prefix.replace(/\{service.name\}/, d.name)
 
 // Replicate CAP's internal _slugified function for service name derivation
 exports.slugified = (name) =>

--- a/lib/utils/service-name.js
+++ b/lib/utils/service-name.js
@@ -1,17 +1,17 @@
 const cds = require('@sap/cds')
 
+const PREFIX = cds.env.mcp?.prefix === true
+
+exports.resolvePrefix =
+  !PREFIX ? () => '' :
+  PREFIX === true ? (d) => d.name + '-' :
+  (d,prefix) => prefix.replace(/\{service.name\}/, d.name)
+
 // Replicate CAP's internal _slugified function for service name derivation
-const slugified = (name) =>
+exports.slugified = (name) =>
   /[^.]+$/
     .exec(name)[0] //> my.very.CatalogService --> CatalogService
     .replace(/Service$/, '') //> CatalogService --> Catalog
     .replace(/_/g, '-') //> foo_bar_baz --> foo-bar-baz
     .replace(/([a-z0-9])([A-Z])/g, (_, c, C) => c + '-' + C) //> ODataFooBarX9 --> OData-Foo-Bar-X9
     .toLowerCase() //> FOO --> foo
-
-// Resolve the tool name prefix for a service definition
-function resolvePrefix(def) {
-  return cds.env.mcp?.prefix === true ? slugified(def.name) : ''
-}
-
-module.exports = { slugified, resolvePrefix }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "watch:sample": "cds w tests/bookshop",
     "watch:sample:hybrid": "cds bind --exec -- cds w tests/bookshop",
-    "inspect": "npx @modelcontextprotocol/inspector --transport \"http\" --server-url \"http://localhost:4004/mcp/catalog\"",
+    "inspect": "npx @modelcontextprotocol/inspector@v1 --transport \"http\" --server-url \"http://localhost:4004/mcp/catalog\"",
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
     "test:hybrid": "cds bind --exec -- npm run test",
     "test:reporting": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --ci --collectCoverage --reporters=default --coverageReporters=text --coverageReporters=cobertura",

--- a/tests/bookshop/srv/cat-service.cds
+++ b/tests/bookshop/srv/cat-service.cds
@@ -79,4 +79,4 @@ annotate CatalogService.Books with {
 };
 
 annotate CatalogService with @mcp @odata;
-annotate CatalogService with @mcp.instructions: 'Use describe to explore available books, genres, and actions. Use query to search the catalog. Use call_action to place orders or perform calculations.';
+annotate CatalogService with @mcp.instructions: 'Use `describe` to explore available books, genres, and actions. Use `query` to search the catalog. Use `call` action to place orders or perform calculations.';

--- a/tests/integration/__snapshots__/catalog-service-card.json
+++ b/tests/integration/__snapshots__/catalog-service-card.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "supportedProtocolVersions": ["2025-11-25"],
   "description": "Catalog service for browsing books.\nProvides read access to the book catalog including genres and au",
-  "instructions": "Use describe to explore available books, genres, and actions. Use query to search the catalog. Use call_action to place orders or perform calculations.",
+  "instructions": "Use `describe` to explore available books, genres, and actions. Use `query` to search the catalog. Use `call` action to place orders or perform calculations.",
   "remotes": [
     {
       "type": "streamable-http",
@@ -612,7 +612,7 @@
       }
     },
     {
-      "name": "call_action",
+      "name": "call",
       "description": "Call an unbound action or function in CatalogService service. Use describe to discover available actions and their parameters.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/tests/integration/actions.test.js
+++ b/tests/integration/actions.test.js
@@ -3,12 +3,12 @@ const test = cds.test(__dirname + '/../bookshop')
 const { expect } = test
 const mcpClient = require('./mcp-test-client')(test)
 
-describe('call_action tool', () => {
+describe('call action tool', () => {
   describe('tool listing', () => {
-    it('includes call_action tool with proper schema', async () => {
+    it('includes call action tool with proper schema', async () => {
       const { mcp } = mcpClient()
       const response = await mcp('tools/list')
-      const callActionTool = response.result.tools.find((t) => t.name === 'call_action')
+      const callActionTool = response.result.tools.find((t) => t.name === 'call')
       expect(callActionTool).to.have.property('description')
       expect(callActionTool).to.have.property('inputSchema')
       expect(callActionTool.inputSchema.properties).to.have.property('action')
@@ -18,7 +18,7 @@ describe('call_action tool', () => {
     it('lists available actions in action enum', async () => {
       const { mcp } = mcpClient()
       const response = await mcp('tools/list')
-      const callActionTool = response.result.tools.find((t) => t.name === 'call_action')
+      const callActionTool = response.result.tools.find((t) => t.name === 'call')
       const actionEnum = callActionTool.inputSchema.properties.action.enum
       expect(actionEnum).to.include('sum')
       expect(actionEnum).to.include('stock')
@@ -30,7 +30,7 @@ describe('call_action tool', () => {
   describe('calling functions', () => {
     it('calls sum function with two integers', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'sum',
         parameters: { x: 3, y: 5 }
       })
@@ -42,7 +42,7 @@ describe('call_action tool', () => {
 
     it('sum returns 0 with no parameters', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'sum'
       })
       expect(error).to.be.null
@@ -51,7 +51,7 @@ describe('call_action tool', () => {
 
     it('sum handles partial parameters', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'sum',
         parameters: { x: 10 }
       })
@@ -61,7 +61,7 @@ describe('call_action tool', () => {
 
     it('calls stock function to get book stock', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'stock',
         parameters: { id: 201 }
       })
@@ -73,7 +73,7 @@ describe('call_action tool', () => {
 
     it('stock returns 0 for non-existent book', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'stock',
         parameters: { id: 9999 }
       })
@@ -85,7 +85,7 @@ describe('call_action tool', () => {
   describe('calling actions', () => {
     it('calls add action', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'add',
         parameters: { x: 10, to: 5 }
       })
@@ -97,7 +97,7 @@ describe('call_action tool', () => {
 
     it('add returns 0 with no parameters', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'add'
       })
       expect(error).to.be.null
@@ -108,7 +108,7 @@ describe('call_action tool', () => {
   describe('error handling', () => {
     it('returns error for unknown action', async () => {
       const { callTool } = mcpClient()
-      const { error } = await callTool('call_action', {
+      const { error } = await callTool('call', {
         action: 'nonExistentAction'
       })
       expect(error).to.match(/not found|invalid/i)
@@ -116,7 +116,7 @@ describe('call_action tool', () => {
 
     it('returns all error details when handler reports multiple errors', async () => {
       const { callTool } = mcpClient()
-      const { error } = await callTool('call_action', {
+      const { error } = await callTool('call', {
         action: 'validateOrder',
         parameters: { book: 0, quantity: 0, email: 'invalid' }
       })
@@ -135,7 +135,7 @@ describe('call_action tool', () => {
     it('lists withMany, withManyCustomTypes, withCustomTypes in action enum', async () => {
       const { mcp } = mcpClient()
       const response = await mcp('tools/list')
-      const callActionTool = response.result.tools.find((t) => t.name === 'call_action')
+      const callActionTool = response.result.tools.find((t) => t.name === 'call')
       const actionEnum = callActionTool.inputSchema.properties.action.enum
       expect(actionEnum).to.include('withMany')
       expect(actionEnum).to.include('withManyCustomTypes')
@@ -144,7 +144,7 @@ describe('call_action tool', () => {
 
     it('calls withMany action with array param', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'withMany',
         parameters: { updates: [{ ID: 'foo' }, { ID: 'bar' }] }
       })
@@ -156,7 +156,7 @@ describe('call_action tool', () => {
 
     it('calls withManyCustomTypes action with array of typed objects', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'withManyCustomTypes',
         parameters: { updates: [{ ID: '1', abc: 'val', def: '2024-06-01T12:00:00Z', prop1: 'p' }] }
       })
@@ -170,7 +170,7 @@ describe('call_action tool', () => {
 
     it('calls withCustomTypes action with scalar custom type param', async () => {
       const { callTool } = mcpClient()
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'withCustomTypes',
         parameters: { prop1: 'myval' }
       })
@@ -183,12 +183,12 @@ describe('call_action tool', () => {
   })
 })
 
-describe('call_action authorization', () => {
+describe('call authorization', () => {
   describe('AdminService (requires admin role)', () => {
     it('includes sum, stock, add actions for admin user', async () => {
       const { mcp } = mcpClient('/mcp/admin', 'alice:')
       const response = await mcp('tools/list')
-      const callActionTool = response.result.tools.find((t) => t.name === 'call_action')
+      const callActionTool = response.result.tools.find((t) => t.name === 'call')
       const actionEnum = callActionTool.inputSchema.properties.action.enum
       expect(actionEnum).to.include('sum')
       expect(actionEnum).to.include('stock')
@@ -197,7 +197,7 @@ describe('call_action authorization', () => {
 
     it('admin can call sum function', async () => {
       const { callTool } = mcpClient('/mcp/admin', 'alice:')
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'sum',
         parameters: { x: 100, y: 200 }
       })
@@ -208,7 +208,7 @@ describe('call_action authorization', () => {
 
     it('admin can call stock function', async () => {
       const { callTool } = mcpClient('/mcp/admin', 'alice:')
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'stock',
         parameters: { id: 252 }
       })
@@ -219,7 +219,7 @@ describe('call_action authorization', () => {
 
     it('admin can call add action', async () => {
       const { callTool } = mcpClient('/mcp/admin', 'alice:')
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'add',
         parameters: { x: 7, to: 3 }
       })
@@ -228,10 +228,10 @@ describe('call_action authorization', () => {
       expect(content.result).to.equal(10)
     })
 
-    it('rejects unauthenticated call_action with 401', async () => {
+    it('rejects unauthenticated call with 401', async () => {
       const { mcp } = mcpClient('/mcp/admin')
       const response = await mcp('tools/call', {
-        name: 'call_action',
+        name: 'call',
         arguments: { action: 'sum', parameters: { x: 1, y: 2 } }
       })
       expect(response.error).to.exist
@@ -239,9 +239,9 @@ describe('call_action authorization', () => {
       expect(response.error.message).to.match(/401/i)
     })
 
-    it('rejects unauthorized user call_action with 403', async () => {
+    it('rejects unauthorized user call with 403', async () => {
       const { callTool } = mcpClient('/mcp/admin', 'bob:')
-      const { error } = await callTool('call_action', {
+      const { error } = await callTool('call', {
         action: 'sum',
         parameters: { x: 1, y: 2 }
       })
@@ -258,24 +258,24 @@ describe('RestrictedService action authorization', () => {
     it('includes add in action enum for admin', async () => {
       const { mcp } = mcpClient('/mcp/restricted', 'alice:')
       const response = await mcp('tools/list')
-      const callActionTool = response.result.tools.find((t) => t.name === 'call_action')
+      const callActionTool = response.result.tools.find((t) => t.name === 'call')
       const actionEnum = callActionTool.inputSchema.properties.action.enum
       expect(actionEnum).to.include('add')
     })
 
-    it('does not list call_action tool for non-admin user (bob)', async () => {
+    it('does not list call tool for non-admin user (bob)', async () => {
       // bob has editor role but add requires admin
       const { mcp } = mcpClient('/mcp/restricted', 'bob:')
       const response = await mcp('tools/list')
       const toolNames = response.result.tools.map((t) => t.name)
-      expect(toolNames).to.not.include('call_action')
+      expect(toolNames).to.not.include('call')
     })
   })
 
   describe('action execution', () => {
     it('admin (alice) can call add action', async () => {
       const { callTool } = mcpClient('/mcp/restricted', 'alice:')
-      const { content, error } = await callTool('call_action', {
+      const { content, error } = await callTool('call', {
         action: 'add',
         parameters: { x: 25, to: 75 }
       })
@@ -284,12 +284,12 @@ describe('RestrictedService action authorization', () => {
       expect(content.result).to.equal(100)
     })
 
-    it('unauthenticated user cannot see call_action tool', async () => {
+    it('unauthenticated user cannot see call tool', async () => {
       // Unauthenticated users have no accessible actions
       const { mcp } = mcpClient('/mcp/restricted')
       const response = await mcp('tools/list')
       const toolNames = response.result.tools.map((t) => t.name)
-      expect(toolNames).to.not.include('call_action')
+      expect(toolNames).to.not.include('call')
     })
   })
 })

--- a/tests/integration/api-ignore.test.js
+++ b/tests/integration/api-ignore.test.js
@@ -95,7 +95,7 @@ describe('@cds.api.ignore annotation', () => {
     it('hides ignored action from tools/list action enum', async () => {
       const { mcp } = mcpClient('/mcp/api-ignore-test')
       const response = await mcp('tools/list')
-      const callActionTool = response.result.tools.find((t) => t.name === 'call_action')
+      const callActionTool = response.result.tools.find((t) => t.name === 'call')
       const actionEnum = callActionTool.inputSchema.properties.action.enum
 
       expect(actionEnum).to.include('visibleAction')
@@ -120,7 +120,7 @@ describe('@cds.api.ignore annotation', () => {
 
       // Try to call the hidden action
       // MCP SDK validates enum and returns an error
-      const { error } = await callTool('call_action', {
+      const { error } = await callTool('call', {
         action: 'hiddenAction',
         parameters: {}
       })

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -22,7 +22,7 @@ describe('MCP Protocol', () => {
     const { initialize } = mcpClient()
     const response = await initialize()
     expect(response.result.instructions).to.equal(
-      'Use describe to explore available books, genres, and actions. Use query to search the catalog. Use call_action to place orders or perform calculations.'
+      'Use `describe` to explore available books, genres, and actions. Use `query` to search the catalog. Use `call` action to place orders or perform calculations.'
     )
   })
 
@@ -30,7 +30,7 @@ describe('MCP Protocol', () => {
     const { initialize } = mcpClient('/mcp/admin', 'alice:')
     const response = await initialize()
     expect(response.result.instructions).to.equal(
-      "Use the 'describe' tool to explore the data model and available actions/functions. Then use 'query' to read data or 'call_action' to invoke actions or functions."
+      "Use the `describe` tool to explore the data model and available actions/functions. Then use `query` to read data or `call` to invoke actions or functions."
     )
   })
 

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -30,7 +30,7 @@ describe('MCP Protocol', () => {
     const { initialize } = mcpClient('/mcp/admin', 'alice:')
     const response = await initialize()
     expect(response.result.instructions).to.equal(
-      "Use the `describe` tool to explore the data model and available actions/functions. Then use `query` to read data or `call` to invoke actions or functions."
+      'Use the `describe` tool to explore the data model and available actions/functions. Then use `query` to read data or `call` to invoke actions or functions.'
     )
   })
 

--- a/tests/integration/per-action-tools.test.js
+++ b/tests/integration/per-action-tools.test.js
@@ -12,7 +12,7 @@ describe('Per-Action Tools', () => {
       const { mcp } = mcpClient()
       const response = await mcp('tools/list')
       const toolNames = response.result.tools.map((t) => t.name)
-      expect(toolNames).to.not.include('call_action')
+      expect(toolNames).to.not.include('call')
       expect(toolNames).to.include('sum')
       expect(toolNames).to.include('stock')
       expect(toolNames).to.include('add')

--- a/tests/integration/prefix.test.js
+++ b/tests/integration/prefix.test.js
@@ -18,26 +18,26 @@ describe('Tool Name Prefix (global prefix: true)', () => {
     initialize = client.initialize
   })
 
-  it('tool names are prefixed with slugified service name', async () => {
+  it('tool names are prefixed with service name', async () => {
     const response = await mcp('tools/list')
     const toolNames = response.result.tools.map((t) => t.name)
-    expect(toolNames).to.include('catalog_query')
-    expect(toolNames).to.include('catalog_describe')
-    expect(toolNames).to.include('catalog_call')
+    expect(toolNames).to.include('CatalogService-query')
+    expect(toolNames).to.include('CatalogService-describe')
+    expect(toolNames).to.include('CatalogService-call')
     expect(toolNames).to.not.include('query')
     expect(toolNames).to.not.include('describe')
     expect(toolNames).to.not.include('call')
   })
 
   it('prefixed tools are callable', async () => {
-    const res = await mcp('tools/call', { name: 'catalog_describe', arguments: {} })
+    const res = await mcp('tools/call', { name: 'CatalogService-describe', arguments: {} })
     expect(res.result.isError).to.not.be.true
     const text = res.result.content[0].text
     expect(text).to.include('Books')
   })
 
   it('prefixed query tool works', async () => {
-    const { content, error } = await callTool('catalog_query', {
+    const { content, error } = await callTool('CatalogService-query', {
       sql: 'SELECT ID, title FROM CatalogService.Books LIMIT 5'
     })
     expect(error).to.be.null
@@ -46,7 +46,7 @@ describe('Tool Name Prefix (global prefix: true)', () => {
   })
 
   it('prefixed call tool works', async () => {
-    const { content, error } = await callTool('catalog_call', {
+    const { content, error } = await callTool('CatalogService-call', {
       action: 'sum',
       parameters: { x: 3, y: 4 }
     })
@@ -57,8 +57,8 @@ describe('Tool Name Prefix (global prefix: true)', () => {
   it('default instructions reference prefixed tool names', async () => {
     const { initialize: limitInit } = mcpClient('/mcp/limit', 'alice:')
     const response = await limitInit()
-    expect(response.result.instructions).to.include('limit_describe')
-    expect(response.result.instructions).to.include('limit_query')
+    expect(response.result.instructions).to.include('LimitService-describe')
+    expect(response.result.instructions).to.include('LimitService-query')
   })
 
   it('custom @mcp.instructions are not modified by prefix', async () => {

--- a/tests/integration/prefix.test.js
+++ b/tests/integration/prefix.test.js
@@ -23,10 +23,10 @@ describe('Tool Name Prefix (global prefix: true)', () => {
     const toolNames = response.result.tools.map((t) => t.name)
     expect(toolNames).to.include('catalog_query')
     expect(toolNames).to.include('catalog_describe')
-    expect(toolNames).to.include('catalog_call_action')
+    expect(toolNames).to.include('catalog_call')
     expect(toolNames).to.not.include('query')
     expect(toolNames).to.not.include('describe')
-    expect(toolNames).to.not.include('call_action')
+    expect(toolNames).to.not.include('call')
   })
 
   it('prefixed tools are callable', async () => {
@@ -45,8 +45,8 @@ describe('Tool Name Prefix (global prefix: true)', () => {
     expect(content.data.length).to.be.greaterThan(0)
   })
 
-  it('prefixed call_action tool works', async () => {
-    const { content, error } = await callTool('catalog_call_action', {
+  it('prefixed call tool works', async () => {
+    const { content, error } = await callTool('catalog_call', {
       action: 'sum',
       parameters: { x: 3, y: 4 }
     })
@@ -64,7 +64,7 @@ describe('Tool Name Prefix (global prefix: true)', () => {
   it('custom @mcp.instructions are not modified by prefix', async () => {
     const response = await initialize()
     expect(response.result.instructions).to.equal(
-      'Use describe to explore available books, genres, and actions. Use query to search the catalog. Use call_action to place orders or perform calculations.'
+      'Use `describe` to explore available books, genres, and actions. Use `query` to search the catalog. Use `call` action to place orders or perform calculations.'
     )
   })
 })


### PR DESCRIPTION
This PR renames the generic `call_action` MCP tool to `call` across the entire codebase and updates the tool name prefix strategy to use the full service name (e.g., `sap.capire.flights.FlightsService-query`) instead of a slugified name (e.g., `flights_query`).

Default: `"{service.name}-"`

Important for GA release 