### PR TITLE
fix: optional tool prefix param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.3.0 - 2026-07-31
+## Version 1.3.1 - 2026-08-03
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.3.1 - 2026-08-03
+## Version 1.4.0 - 2026-08-03
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## Version 1.3.0 - 2026-07-31
 
+### Fixed
+
+- Set tool prefix as optional parameter
+
+## Version 1.3.0 - 2026-07-31
+
 ### Changed
 
 - Renamed the `call_action` tool to `call`

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -204,7 +204,7 @@ function createCallActionToolDefinition(actionNames, serviceName, prefix = '') {
 }
 
 // Register a single generic query tool for all entities (default behavior)
-function registerGenericReadTool(server, srv, entities, prefix, { log = LOG }) {
+function registerGenericReadTool(server, srv, entities, prefix, { log = LOG } = {}) {
   const entityNames = Object.keys(entities)
   if (entityNames.length === 0) {
     log.debug('No entities to register tools for', { service: srv.name })
@@ -227,7 +227,7 @@ function registerGenericReadTool(server, srv, entities, prefix, { log = LOG }) {
 }
 
 // Register the describe tool for service introspection
-function registerDescribeTool(server, srv, entities, actions = {}, prefix, { log = LOG }) {
+function registerDescribeTool(server, srv, entities, actions = {}, prefix, { log = LOG } = {}) {
   const entityNames = Object.keys(entities)
   const actionNames = Object.keys(actions)
   if (entityNames.length === 0 && actionNames.length === 0) {
@@ -251,7 +251,7 @@ function registerDescribeTool(server, srv, entities, actions = {}, prefix, { log
 }
 
 // Register the call tool for invoking unbound actions/functions
-function registerCallActionTool(server, srv, actions, prefix, { log = LOG }) {
+function registerCallActionTool(server, srv, actions, prefix, { log = LOG } = {}) {
   const actionNames = Object.keys(actions)
   if (actionNames.length === 0) return // No actions to register
 
@@ -349,7 +349,7 @@ function createPerActionToolDefinition(actionName, action, serviceName, model, p
 
 // Register individual tools per action/function
 
-function registerPerActionTools(server, srv, actions, prefix, { log = LOG }) {
+function registerPerActionTools(server, srv, actions, prefix, { log = LOG } = {}) {
   const actionEntries = Object.entries(actions)
   if (actionEntries.length === 0) {
     log.debug('No actions to register tools for', { service: srv.name })
@@ -374,7 +374,7 @@ function registerPerActionTools(server, srv, actions, prefix, { log = LOG }) {
 }
 
 // Execute a per-action tool (args ARE the parameters directly)
-async function executePerActionTool(srv, actionName, action, args, { log = LOG }) {
+async function executePerActionTool(srv, actionName, action, args, { log = LOG } = {}) {
   log(actionName, fmt({ service: srv.name, ...buildQueryArgs(args) }))
 
   try {
@@ -403,7 +403,7 @@ async function executePerActionTool(srv, actionName, action, args, { log = LOG }
   }
 }
 
-async function executeGenericReadTool(srv, entities, args, { log = LOG }) {
+async function executeGenericReadTool(srv, entities, args, { log = LOG } = {}) {
   if (cds.env.mcp?.format === 'cql') {
     return _executeGenericReadSql(srv, entities, args, { log })
   }
@@ -495,7 +495,7 @@ function _enforceSelectLimit(cqn, targetEntity, srv) {
 }
 
 // SQL mode: parse → shared core → SQL response
-async function _executeGenericReadSql(srv, entities, args, { log = LOG }) {
+async function _executeGenericReadSql(srv, entities, args, { log = LOG } = {}) {
   const rawSql = args.sql ?? ''
 
   const maxLength = cds.env.mcp?.cql?.maxLength ?? DEFAULT_CQL_MAX_LENGTH
@@ -548,7 +548,7 @@ async function _executeGenericReadSql(srv, entities, args, { log = LOG }) {
 }
 
 // CQN mode: build CQN → shared core → CQN response
-async function _executeGenericReadCqn(srv, entities, args, { log = LOG }) {
+async function _executeGenericReadCqn(srv, entities, args, { log = LOG } = {}) {
   const { entity: entityName } = args
   log('query', fmt({ service: srv.name, ...buildQueryArgs(args) }))
 
@@ -626,12 +626,12 @@ async function _executeGenericReadCqn(srv, entities, args, { log = LOG }) {
   }
 }
 
-async function executeDescribe(srv, entities, actions, args, { log = LOG }) {
+async function executeDescribe(srv, entities, actions, args, { log = LOG } = {}) {
   return _executeDescribeCsn(srv, entities, actions, args, { log })
 }
 
 // CSN format (default): return JSON with element metadata
-async function _executeDescribeCsn(srv, entities, actions, args, { log = LOG }) {
+async function _executeDescribeCsn(srv, entities, actions, args, { log = LOG } = {}) {
   // Determine what to include:
   // - If only entity specified => return only those entities (no actions)
   // - If only action specified => return only those actions (no entities)
@@ -794,7 +794,7 @@ async function _executeDescribeCsn(srv, entities, actions, args, { log = LOG }) 
   }
 }
 
-async function executeCallActionTool(srv, actions, args, { log = LOG }) {
+async function executeCallActionTool(srv, actions, args, { log = LOG } = {}) {
   const { action: actionName, parameters = {} } = args
   log(
     'call',

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -122,7 +122,7 @@ function validateFields(fields, entity, definitions) {
   })
 }
 
-function createGenericReadToolDefinition(entityNames, serviceName, prefix) {
+function createGenericReadToolDefinition(entityNames, serviceName, prefix = '') {
   const name = prefix + 'query'
   if (cds.env.mcp?.format === 'cql') {
     return {
@@ -155,7 +155,7 @@ function createGenericReadToolDefinition(entityNames, serviceName, prefix) {
   }
 }
 
-function createDescribeToolDefinition(entityNames, actionNames, serviceName, prefix) {
+function createDescribeToolDefinition(entityNames, actionNames, serviceName, prefix = '') {
   const schemaFields = {}
 
   if (entityNames.length > 0) {
@@ -188,7 +188,7 @@ function createDescribeToolDefinition(entityNames, actionNames, serviceName, pre
   }
 }
 
-function createCallActionToolDefinition(actionNames, serviceName, prefix) {
+function createCallActionToolDefinition(actionNames, serviceName, prefix = '') {
   const name = prefix + 'call'
   return {
     name,
@@ -324,7 +324,7 @@ function describeReturns(action, model) {
 }
 
 // Per-action tool definition factory (shared with compile.js)
-function createPerActionToolDefinition(actionName, action, serviceName, model, prefix) {
+function createPerActionToolDefinition(actionName, action, serviceName, model, prefix = '') {
   let description = getDescription(action) || `Call ${action.kind} ${actionName} in ${serviceName}`
 
   // Append return type info so LLMs know without calling describe

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -204,7 +204,7 @@ function createCallActionToolDefinition(actionNames, serviceName, prefix = '') {
 }
 
 // Register a single generic query tool for all entities (default behavior)
-function registerGenericReadTool(server, srv, entities, prefix, { log = LOG } = {}) {
+function registerGenericReadTool(server, srv, entities, prefix, { log = LOG }) {
   const entityNames = Object.keys(entities)
   if (entityNames.length === 0) {
     log.debug('No entities to register tools for', { service: srv.name })
@@ -227,7 +227,7 @@ function registerGenericReadTool(server, srv, entities, prefix, { log = LOG } = 
 }
 
 // Register the describe tool for service introspection
-function registerDescribeTool(server, srv, entities, actions = {}, prefix, { log = LOG } = {}) {
+function registerDescribeTool(server, srv, entities, actions = {}, prefix, { log = LOG }) {
   const entityNames = Object.keys(entities)
   const actionNames = Object.keys(actions)
   if (entityNames.length === 0 && actionNames.length === 0) {
@@ -251,7 +251,7 @@ function registerDescribeTool(server, srv, entities, actions = {}, prefix, { log
 }
 
 // Register the call tool for invoking unbound actions/functions
-function registerCallActionTool(server, srv, actions, prefix, { log = LOG } = {}) {
+function registerCallActionTool(server, srv, actions, prefix, { log = LOG }) {
   const actionNames = Object.keys(actions)
   if (actionNames.length === 0) return // No actions to register
 
@@ -349,7 +349,7 @@ function createPerActionToolDefinition(actionName, action, serviceName, model, p
 
 // Register individual tools per action/function
 
-function registerPerActionTools(server, srv, actions, prefix, { log = LOG } = {}) {
+function registerPerActionTools(server, srv, actions, prefix, { log = LOG }) {
   const actionEntries = Object.entries(actions)
   if (actionEntries.length === 0) {
     log.debug('No actions to register tools for', { service: srv.name })
@@ -374,7 +374,7 @@ function registerPerActionTools(server, srv, actions, prefix, { log = LOG } = {}
 }
 
 // Execute a per-action tool (args ARE the parameters directly)
-async function executePerActionTool(srv, actionName, action, args, { log = LOG } = {}) {
+async function executePerActionTool(srv, actionName, action, args, { log = LOG }) {
   log(actionName, fmt({ service: srv.name, ...buildQueryArgs(args) }))
 
   try {
@@ -403,7 +403,7 @@ async function executePerActionTool(srv, actionName, action, args, { log = LOG }
   }
 }
 
-async function executeGenericReadTool(srv, entities, args, { log = LOG } = {}) {
+async function executeGenericReadTool(srv, entities, args, { log = LOG }) {
   if (cds.env.mcp?.format === 'cql') {
     return _executeGenericReadSql(srv, entities, args, { log })
   }
@@ -495,7 +495,7 @@ function _enforceSelectLimit(cqn, targetEntity, srv) {
 }
 
 // SQL mode: parse → shared core → SQL response
-async function _executeGenericReadSql(srv, entities, args, { log = LOG } = {}) {
+async function _executeGenericReadSql(srv, entities, args, { log = LOG }) {
   const rawSql = args.sql ?? ''
 
   const maxLength = cds.env.mcp?.cql?.maxLength ?? DEFAULT_CQL_MAX_LENGTH
@@ -548,7 +548,7 @@ async function _executeGenericReadSql(srv, entities, args, { log = LOG } = {}) {
 }
 
 // CQN mode: build CQN → shared core → CQN response
-async function _executeGenericReadCqn(srv, entities, args, { log = LOG } = {}) {
+async function _executeGenericReadCqn(srv, entities, args, { log = LOG }) {
   const { entity: entityName } = args
   log('query', fmt({ service: srv.name, ...buildQueryArgs(args) }))
 
@@ -626,12 +626,12 @@ async function _executeGenericReadCqn(srv, entities, args, { log = LOG } = {}) {
   }
 }
 
-async function executeDescribe(srv, entities, actions, args, { log = LOG } = {}) {
+async function executeDescribe(srv, entities, actions, args, { log = LOG }) {
   return _executeDescribeCsn(srv, entities, actions, args, { log })
 }
 
 // CSN format (default): return JSON with element metadata
-async function _executeDescribeCsn(srv, entities, actions, args, { log = LOG } = {}) {
+async function _executeDescribeCsn(srv, entities, actions, args, { log = LOG }) {
   // Determine what to include:
   // - If only entity specified => return only those entities (no actions)
   // - If only action specified => return only those actions (no entities)
@@ -794,7 +794,7 @@ async function _executeDescribeCsn(srv, entities, actions, args, { log = LOG } =
   }
 }
 
-async function executeCallActionTool(srv, actions, args, { log = LOG } = {}) {
+async function executeCallActionTool(srv, actions, args, { log = LOG }) {
   const { action: actionName, parameters = {} } = args
   log(
     'call',

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -626,7 +626,7 @@ async function _executeGenericReadCqn(srv, entities, args, { log = LOG } = {}) {
   }
 }
 
-async function executeDescribe(srv, entities, actions, args, { log = LOG } = {}) {
+async function executeDescribe(srv, entities, actions, args) {
   return _executeDescribeCsn(srv, entities, actions, args, { log: LOG })
 }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -627,7 +627,7 @@ async function _executeGenericReadCqn(srv, entities, args, { log = LOG } = {}) {
 }
 
 async function executeDescribe(srv, entities, actions, args, { log = LOG } = {}) {
-  return _executeDescribeCsn(srv, entities, actions, args, { log: LOG })
+  return _executeDescribeCsn(srv, entities, actions, args, { log })
 }
 
 // CSN format (default): return JSON with element metadata

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -626,7 +626,7 @@ async function _executeGenericReadCqn(srv, entities, args, { log = LOG } = {}) {
   }
 }
 
-async function executeDescribe(srv, entities, actions, args) {
+async function executeDescribe(srv, entities, actions, args, { log = LOG } = {}) {
   return _executeDescribeCsn(srv, entities, actions, args, { log: LOG })
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "CAP plugin to expose services as MCP servers for AI agent consumption",
   "repository": "cap-js/mcp",
   "files": [


### PR DESCRIPTION
## fix: Make tool prefix parameter optional in tool definition functions

### Change Type: 🐛 Bug Fix

This patch release makes the `prefix` parameter optional (defaulting to an empty string `''`) across all tool definition factory functions in `lib/tools.js`, preventing potential errors when the parameter is not provided.

### Changes

- **`lib/tools.js`**: Added default value `= ''` to the `prefix` parameter in the following functions:
  - `createGenericReadToolDefinition`
  - `createDescribeToolDefinition`
  - `createCallActionToolDefinition`
  - `createPerActionToolDefinition`

- **`package.json`**: Bumped version from `1.3.0` → `1.3.1`

- **`CHANGELOG.md`**: Added changelog entry for the fix under a new patch version section

### Have you...

- [x] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.14`

- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `c7ac8980-8f13-11f1-8ccd-e28c46af7b14`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: Repository PR Template
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
</details>
