### PR TITLE
feat: migrate to the new @modelcontextprotocol/sdk v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Version 1.4.0 - tbd
 
 ### Changed
+
 - Migrated from `@modelcontextprotocol/sdk` to the new split packages `@modelcontextprotocol/server` and `@modelcontextprotocol/node` (SDK 2.0.0)
 
 ## Version 1.3.0 - 2026-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 1.4.0 - tbd
+
+### Changed
+- Migrated from `@modelcontextprotocol/sdk` to the new split packages `@modelcontextprotocol/server` and `@modelcontextprotocol/node` (SDK 2.0.0)
+
 ## Version 1.3.0 - 2026-07-31
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,7 @@
 const cds = require('@sap/cds')
 const express = require('express')
-const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js')
-const {
-  StreamableHTTPServerTransport
-} = require('@modelcontextprotocol/sdk/server/streamableHttp.js')
-const { ListToolsRequestSchema } = require('@modelcontextprotocol/sdk/types.js')
+const { McpServer, ListToolsRequest, createMcpHandler } = require('@modelcontextprotocol/server')
+const { toNodeHandler } = require('@modelcontextprotocol/node')
 const {
   registerGenericReadTool,
   registerCallActionTool,
@@ -69,62 +66,38 @@ module.exports = function McpProtocolAdapter(srv) {
 
       const prefix = resolvePrefix(srv.definition)
 
-      const server = new McpServer(
-        {
-          name: srv.name,
-          version: '1.0.0',
-          description: getDescription(srv.definition) || `MCP server for ${srv.name}`
-        },
-        {
-          instructions: getInstructions(srv.definition, null, prefix)
-        }
-      )
+      const factory = () => {
+        const server = new McpServer(
+          {
+            name: srv.name,
+            version: '1.0.0',
+            description: getDescription(srv.definition) || `MCP server for ${srv.name}`
+          },
+          {
+            instructions: getInstructions(srv.definition, null, prefix)
+          }
+        )
 
-      const entityCount = Object.keys(entities).length
-      const actionCount = Object.keys(actions).length
-      if (entityCount > 0 || actionCount > 0) {
-        registerDescribeTool(server, srv, entities, actions, prefix)
-        registerGenericReadTool(server, srv, entities, prefix)
-        registerActionTool(server, srv, actions, prefix)
-      } else {
-        // No accessible entities - register empty tools capability
-        server.server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }))
-        LOG.debug('Registered empty tool list', { service: srv.name })
-      }
-
-      // Tools are statically determined per request - no runtime list changes
-      server.server.registerCapabilities({ tools: { listChanged: false } })
-
-      // Detect response format from Accept header
-      const accept = req.headers['accept'] || ''
-      const acceptsJson = accept.includes('application/json')
-      const acceptsSse = accept.includes('text/event-stream')
-
-      // Auto-detect: if client only accepts JSON, use JSON response mode
-      const enableJsonResponse = acceptsJson && !acceptsSse
-
-      // Ensure Accept header satisfies SDK validation (requires both)
-      if (!acceptsJson || !acceptsSse) {
-        const newAccept = 'application/json, text/event-stream'
-        req.headers['accept'] = newAccept
-        // Also patch rawHeaders (used by @hono/node-server for web Request conversion)
-        const idx = req.rawHeaders.findIndex((h) => h.toLowerCase() === 'accept')
-        if (idx !== -1) {
-          req.rawHeaders[idx + 1] = newAccept
+        const entityCount = Object.keys(entities).length
+        const actionCount = Object.keys(actions).length
+        if (entityCount > 0 || actionCount > 0) {
+          registerDescribeTool(server, srv, entities, actions, prefix)
+          registerGenericReadTool(server, srv, entities, prefix)
+          registerActionTool(server, srv, actions, prefix)
         } else {
-          req.rawHeaders.push('Accept', newAccept)
+          // No accessible entities - register empty tools capability
+          server.server.setRequestHandler(ListToolsRequest, () => ({ tools: [] }))
+          LOG.debug('Registered empty tool list', { service: srv.name })
         }
+
+        // Tools are statically determined per request - no runtime list changes
+        server.server.registerCapabilities({ tools: { listChanged: false } })
+
+        return server
       }
 
-      // Create stateless transport
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-        enableJsonResponse
-      })
-
-      await server.connect(transport)
-      await transport.handleRequest(req, res, req.body)
-      await server.close()
+      const handler = createMcpHandler(factory)
+      await toNodeHandler(handler)(req, res, req.body)
     } catch (err) {
       LOG.error('MCP request failed', { service: srv.name, error: err.message })
       if (!res.headersSent) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const cds = require('@sap/cds')
 const express = require('express')
-const { McpServer, ListToolsRequest, createMcpHandler } = require('@modelcontextprotocol/server')
+const { McpServer, createMcpHandler } = require('@modelcontextprotocol/server')
 const { toNodeHandler } = require('@modelcontextprotocol/node')
 const {
   registerGenericReadTool,
@@ -86,8 +86,10 @@ module.exports = function McpProtocolAdapter(srv) {
           registerActionTool(server, srv, actions, prefix)
         } else {
           // No accessible entities - register empty tools capability
-          server.server.setRequestHandler(ListToolsRequest, () => ({ tools: [] }))
+          server.server.registerCapabilities({ tools: { listChanged: false } })
+          server.server.setRequestHandler('tools/list', () => ({ tools: [] }))
           LOG.debug('Registered empty tool list', { service: srv.name })
+          return server
         }
 
         // Tools are statically determined per request - no runtime list changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/mcp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "CAP plugin to expose services as MCP servers for AI agent consumption",
   "repository": "cap-js/mcp",
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@toon-format/toon": ">=2.3",
     "zod": "^4.3.6"
   },

--- a/tests/bookshop/srv/fully-restricted-service.cds
+++ b/tests/bookshop/srv/fully-restricted-service.cds
@@ -15,3 +15,13 @@ annotate FullyRestrictedService.Authors with @(restrict: [{
   grant: 'READ',
   to   : 'editor'
 }]);
+
+annotate FullyRestrictedService.Genres with @(restrict: [{
+  grant: 'READ',
+  to   : 'admin'
+}]);
+
+annotate FullyRestrictedService.Currencies with @(restrict: [{
+  grant: 'READ',
+  to   : 'admin'
+}]);

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -37,7 +37,7 @@ describe('MCP Protocol', () => {
   it('handles invalid JSON body gracefully', async () => {
     const response = await fetch(`${test.url}/mcp/catalog`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
       body: 'this is not valid json {'
     })
 

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -1734,51 +1734,33 @@ describe('Entity-Level Authorization (RestrictedService)', () => {
 })
 
 describe('No Accessible Entities (FullyRestrictedService)', () => {
-  describe('alice (admin role)', () => {
-    it('can access Books entity plus autoexpose entities', async () => {
-      const { mcp } = mcpClient('/mcp/fully-restricted', 'alice:')
-      const response = await mcp('tools/list')
-      const readQueryTool = response.result.tools.find((t) => t.name === 'query')
-      const entityEnum = readQueryTool.inputSchema.properties.entity.enum
-      // alice (admin) can access Books (restricted to admin) + entities with @cds.autoexpose
-      expect(entityEnum).to.include('Books')
-      expect(entityEnum).to.include.members(['Genres', 'Currencies'])
-      // Composition-only autoexposed entities should be filtered out
-      expect(entityEnum).to.not.include('Books.chapters')
-      // Authors is restricted to editor, so alice cannot access it
-      expect(entityEnum).to.not.include('Authors')
-    })
+
+  it('can access Books entity with admin role (alice)', async () => {
+    const { mcp } = mcpClient('/mcp/fully-restricted', 'alice:')
+    const response = await mcp('tools/list')
+    const readQueryTool = response.result.tools.find((t) => t.name === 'query')
+    const entityEnum = readQueryTool.inputSchema.properties.entity.enum
+    // alice (admin) can access Books (restricted to admin)
+    expect(entityEnum).to.include('Books')
+    // Composition-only autoexposed entities should be filtered out
+    expect(entityEnum).to.not.include('Books.chapters')
+    // Authors is restricted to editor, so alice cannot access it
+    expect(entityEnum).to.not.include('Authors')
   })
 
-  describe('bob (no roles) - only autoexpose entities accessible', () => {
-    it('returns tools with only autoexpose entities', async () => {
-      const { mcp } = mcpClient('/mcp/fully-restricted', 'bob:')
-      const response = await mcp('tools/list')
-      expect(response.error).to.not.exist
-      // bob has no roles but can still access entities with @cds.autoexpose
-      const readQueryTool = response.result.tools.find((t) => t.name === 'query')
-      expect(readQueryTool).to.exist
-      const entityEnum = readQueryTool.inputSchema.properties.entity.enum
-      expect(entityEnum).to.include.members(['Genres', 'Currencies'])
-      expect(entityEnum).to.not.include('Books.chapters')
-      expect(entityEnum).to.not.include('Books')
-      expect(entityEnum).to.not.include('Authors')
-    })
+  it('returns empty tools when authenticated but no entities are accessible (bob)', async () => {
+    const { mcp } = mcpClient('/mcp/fully-restricted', 'bob:')
+    const response = await mcp('tools/list')
+    expect(response.error).to.not.exist
+    // bob has no roles and cannot access any entities, so no tools are exposed
+    expect(response.result.tools).to.deep.equal([]);
   })
 
-  describe('unauthenticated - only autoexpose entities accessible', () => {
-    it('returns tools with only autoexpose entities', async () => {
-      const { mcp } = mcpClient('/mcp/fully-restricted')
-      const response = await mcp('tools/list')
-      expect(response.error).to.not.exist
-      // unauthenticated users can still access entities with @cds.autoexpose
-      const readQueryTool = response.result.tools.find((t) => t.name === 'query')
-      expect(readQueryTool).to.exist
-      const entityEnum = readQueryTool.inputSchema.properties.entity.enum
-      expect(entityEnum).to.include.members(['Genres', 'Currencies'])
-      expect(entityEnum).to.not.include('Books.chapters')
-      expect(entityEnum).to.not.include('Books')
-      expect(entityEnum).to.not.include('Authors')
-    })
+  it('returns empty tools when unauthenticated', async () => {
+    const { mcp } = mcpClient('/mcp/fully-restricted')
+    const response = await mcp('tools/list')
+    expect(response.error).to.not.exist
+    // Genres and Currencies are restricted to admin, so unauthenticated users get no tools
+    expect(response.result.tools).to.deep.equal([])
   })
 })

--- a/tests/integration/integration.test.js
+++ b/tests/integration/integration.test.js
@@ -37,7 +37,10 @@ describe('MCP Protocol', () => {
   it('handles invalid JSON body gracefully', async () => {
     const response = await fetch(`${test.url}/mcp/catalog`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      },
       body: 'this is not valid json {'
     })
 
@@ -1734,7 +1737,6 @@ describe('Entity-Level Authorization (RestrictedService)', () => {
 })
 
 describe('No Accessible Entities (FullyRestrictedService)', () => {
-
   it('can access Books entity with admin role (alice)', async () => {
     const { mcp } = mcpClient('/mcp/fully-restricted', 'alice:')
     const response = await mcp('tools/list')
@@ -1753,7 +1755,7 @@ describe('No Accessible Entities (FullyRestrictedService)', () => {
     const response = await mcp('tools/list')
     expect(response.error).to.not.exist
     // bob has no roles and cannot access any entities, so no tools are exposed
-    expect(response.result.tools).to.deep.equal([]);
+    expect(response.result.tools).to.deep.equal([])
   })
 
   it('returns empty tools when unauthenticated', async () => {


### PR DESCRIPTION
The version 2 of `@modelcontextprotocol/sdk` is out of beta and splits the package into server and client. The `cap-js/mcp` adapter only requires the server package which should reduce the overall package size. 
- Followed the migration guide: https://ts.sdk.modelcontextprotocol.io/v2/migration/upgrade-to-v2.html
