### PR TITLE
ci: add lint & prettier workflow to the merge queue

### DIFF
--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, auto_merge_enabled]
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
The merge queue is currently stuck because it has to run all required checks (including linter & prettier) but the linter & prettier job doesn't run in merge queue yet.
