### PR TITLE
fix: remove CQL in the output of query tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Clarified server instructions and `query` tool description to emphasize using `describe` before querying
+- `query` tool response no longer echoes the executed CQL string
 
 ## Version 1.4.0 - 2026-08-03
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -549,7 +549,7 @@ async function _executeGenericReadCql(srv, entities, args, { log = LOG } = {}) {
     )
   }
 
-  const structured = { cql, count: res.count, data: res.data }
+  const structured = { count: res.count, data: res.data }
   return {
     content: [{ type: 'text', text: formatResult(structured) }],
     structuredContent: structured

--- a/tests/integration/sql-format.test.js
+++ b/tests/integration/sql-format.test.js
@@ -125,14 +125,6 @@ describe('SQL Format Mode (cds.env.mcp.format = "cql")', () => {
       expect(content.count).to.equal(amt)
     })
 
-    it('returns original sql in result', async () => {
-      const { callTool } = mcpClient()
-      const cql = 'SELECT ID FROM CatalogService.Books LIMIT 1'
-      const { content, error } = await callTool('query', { cql })
-      expect(error).to.be.null
-      expect(content.cql).to.equal(cql)
-    })
-
     it('handles multiline SQL (LLM often generates newlines before FROM/WHERE)', async () => {
       const { callTool } = mcpClient()
       const { content, error } = await callTool('query', {


### PR DESCRIPTION
Currently, the `query` tool returns the provided CQL in the tool response. The PR removes this redundant echoing. 