### PR TITLE
chore: license fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
     same "printed page" as the copyright notice for easier
     identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2026 SAP SE
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -58,7 +58,7 @@ APPENDIX: How to apply the Apache License to your work.
 
 To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2026 SAP SE
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## 🔧 Fix License Copyright Placeholder

### Change Type: `Chore`

Replaces the placeholder copyright text in the Apache License files with the actual copyright owner information.

### What Changed

Updated the copyright notice in two license files:

| File | Change |
|------|--------|
| `LICENSE` | Replaced `Copyright [yyyy] [name of copyright owner]` → `Copyright 2026 SAP SE` |
| `LICENSES/Apache-2.0.txt` | Replaced `Copyright [yyyy] [name of copyright owner]` → `Copyright 2026 SAP SE` |

Both files previously contained the default Apache License boilerplate placeholder and have now been updated to reflect the correct copyright year and owner (`SAP SE`).

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18`

- Output Template: Repository PR Template
- Correlation ID: `0833b7e0-94b3-11f1-9565-4e5bc906d609`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
</details>
