### PR TITLE
fix: cql as default w/o config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Version 1.4.2 - 2026-08-11
 
 ### Fixed
+
 - Use `format: cql` as default if the `cds.mcp.format` option is not applied
 
 ## Version 1.4.1 - 2026-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 1.4.2 - 2026-08-11
+
+### Fixed
+- Use `format: cql` as default if the `cds.mcp.format` option is not applied
+
 ## Version 1.4.1 - 2026-08-07
 
 ### Changed

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -125,25 +125,11 @@ function validateFields(fields, entity, definitions) {
 
 function createGenericReadToolDefinition(entityNames, serviceName, prefix = '') {
   const name = prefix + 'query'
-  if (cds.env.mcp?.format === 'cql') {
+  if (cds.env.mcp?.format === 'cqn') {
     return {
       name,
-      description:
-        `Query any entity in ${serviceName} service.` +
-        "Ensure to first use the `describe` tool to discover an entity's available fields.",
-      inputSchema: z.object({
-        cql: z
-          .string()
-          .describe(
-            'CAP CQL statement to execute queries; only SELECT statements are allowed. ' +
-              'CQL is a superset of SQL, that supports ' +
-              '- path expressions to follow associations instead of JOINs, e.g. SELECT author.name from Books, ' +
-              '- postfix projection syntax, with nested expands, e.g. SELECT from Authors { ID, name, books { ID, title }}, ' +
-              '- standard CAP/OData functions and aggregates (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). ' +
-              'Database functions (CURRENT_USER, SESSION_USER, SYSUUID, CURRENT_SCHEMA) are not supported. ' +
-              'LIMIT is auto-injected to the service max.'
-          )
-      }),
+      description: `Query any entity in ${serviceName} service. Use describe to discover available entities and their fields.`,
+      inputSchema: createReadInputSchema({ entityNames }),
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,
@@ -154,8 +140,22 @@ function createGenericReadToolDefinition(entityNames, serviceName, prefix = '') 
 
   return {
     name,
-    description: `Query any entity in ${serviceName} service. Use describe to discover available entities and their fields.`,
-    inputSchema: createReadInputSchema({ entityNames }),
+    description:
+      `Query any entity in ${serviceName} service.` +
+      "Ensure to first use the `describe` tool to discover an entity's available fields.",
+    inputSchema: z.object({
+      cql: z
+        .string()
+        .describe(
+          'CAP CQL statement to execute queries; only SELECT statements are allowed. ' +
+            'CQL is a superset of SQL, that supports ' +
+            '- path expressions to follow associations instead of JOINs, e.g. SELECT author.name from Books, ' +
+            '- postfix projection syntax, with nested expands, e.g. SELECT from Authors { ID, name, books { ID, title }}, ' +
+            '- standard CAP/OData functions and aggregates (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). ' +
+            'Database functions (CURRENT_USER, SESSION_USER, SYSUUID, CURRENT_SCHEMA) are not supported. ' +
+            'LIMIT is auto-injected to the service max.'
+        )
+    }),
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -413,10 +413,10 @@ async function executePerActionTool(srv, actionName, action, args, { log = LOG }
 }
 
 async function executeGenericReadTool(srv, entities, args, { log = LOG } = {}) {
-  if (cds.env.mcp?.format === 'cql') {
-    return _executeGenericReadCql(srv, entities, args, { log })
+  if (cds.env.mcp?.format === 'cqn') {
+    return _executeGenericReadCqn(srv, entities, args, { log })
   }
-  return _executeGenericReadCqn(srv, entities, args, { log })
+  return _executeGenericReadCql(srv, entities, args, { log })
 }
 
 // Default CQL length cap. Override via cds.env.mcp.cql.maxLength.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/mcp",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "CAP plugin to expose services as MCP servers for AI agent consumption",
   "repository": "cap-js/mcp",
   "files": [


### PR DESCRIPTION
For consumers that have a peerDependency on cap-js/mcp but dont install the package themselves, do not get the config option applied to set the default format. When none was found, cqn was still the default.