### PR TITLE
fix: remove entities from index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Use `format: cql` as default if the `cds.mcp.format` option is not applied
+- Entities from MCP-enabled services are not shown on index page
 
 ## Version 1.4.1 - 2026-08-07
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -4,6 +4,31 @@ const DEBUG = cds.debug('mcp')
 // Register compile targets (cds compile -2 mcp)
 require('./lib/api').registerCompileTargets()
 
+cds.on('bootstrap', (app) => {
+  const profiles = cds.env.profiles || []
+  const isDev = profiles.includes('development') && !profiles.includes('production')
+  if (!isDev) return
+  if (cds.env.server?.index === false) return
+
+  const MCP_BLOCK = /(<div id="[^"]+-mcp">[\s\S]*?<\/h3>)[\s\S]*?<\/ul>\s*<\/div>/g
+
+  app.get('/', (_req, res, next) => {
+    try {
+      const { path, isfile } = cds.utils
+      const staticIndex = path.join(cds.root, cds.env.folders?.app || 'app/', 'index.html')
+      if (isfile(staticIndex)) return next() // user-provided index.html wins
+      const html = require('@sap/cds/app/index').html.replace(
+        MCP_BLOCK,
+        (_m, head) => `${head}\n      </div>`
+      )
+      return res.type('html').send(html)
+    } catch (e) {
+      DEBUG?.('failed to render patched welcome page:', e.message)
+      return next()
+    }
+  })
+})
+
 cds.once('listening', ({ url }) => {
   const profiles = cds.env.profiles || []
   const isDev = profiles.includes('development') && !profiles.includes('test')


### PR DESCRIPTION
## fix: Remove MCP Service Entities from Index Page

This PR prevents entities from MCP-enabled services from appearing on the CAP welcome/index page in development mode.

### What Changed

**`cds-plugin.js`**
A new `bootstrap` handler intercepts requests to the root index page (`/`) during development and patches the generated HTML. It uses a regex (`MCP_BLOCK`) to strip the entity list items from any `<div>` blocks belonging to MCP services, leaving only the section header. This only activates when:
- Running in `development` profile (and not `production`)
- The server index page is not explicitly disabled (`cds.env.server?.index !== false`)
- No user-provided `app/index.html` exists (which takes precedence)

**`CHANGELOG.md`**
Added a changelog entry under version `1.4.2` noting the fix.

### Category
🐛 **Bug Fix**

### Have you...

- [x] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18`

- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: Repository PR Template
- Correlation ID: `0a07c9a0-9579-11f1-983d-d2978aa3198f`
</details>
