### PR TITLE
fix: entity + service auth filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.4.3 - TBD
+## Version 1.4.3 - 2026-08-13
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 1.4.3 - TBD
+
+### Fixed
+
+- Entity `@requires` and action `@restrict` annotations are now respected when filtering tool context
+
 ## Version 1.4.2 - 2026-08-11
 
 ### Fixed

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,28 +1,31 @@
 const cds = require('@sap/cds')
 
+function _hasRole(user, role) {
+  if (role === 'any') return true
+  if (role === 'authenticated-user') return !!(user && user.id !== 'anonymous')
+  if (role === 'system-user') return !!(user?.is?.('system-user'))
+  return !!(user?.is?.(role))
+}
+
+function _matchesToRoles(toRoles, user) {
+  // No 'to' clause means 'any' pseudo-role — all users including unauthenticated
+  if (!toRoles) return true
+  const roles = Array.isArray(toRoles) ? toRoles : [toRoles]
+  return roles.some(role => _hasRole(user, role))
+}
+
 function checkEntityReadAccess(entity, user) {
+  // @requires on entity is shorthand for @restrict: [{ grant: '*', to: <roles> }]
+  const requires = entity['@requires']
+  if (requires) return _matchesToRoles(requires, user)
+
   const restrict = entity['@restrict']
   if (!restrict) return true
 
   for (const privilege of restrict) {
     const grants = Array.isArray(privilege.grant) ? privilege.grant : [privilege.grant]
     if (!grants.includes('READ') && !grants.includes('*')) continue
-
-    const toRoles = privilege.to
-    if (!toRoles) {
-      if (user && user.id !== 'anonymous') return true
-      continue
-    }
-
-    const roles = Array.isArray(toRoles) ? toRoles : [toRoles]
-    for (const role of roles) {
-      if (role === 'any') return true
-      if (role === 'authenticated-user') {
-        if (user && user.id !== 'anonymous') return true
-        continue
-      }
-      if (user?.is?.(role)) return true
-    }
+    if (_matchesToRoles(privilege.to, user)) return true
   }
   return false
 }
@@ -34,21 +37,18 @@ function getAccessibleEntities(entities, user) {
   )
 }
 
-// Check if user can execute an action/function based on @requires
+// Check if user can execute an action/function based on @requires or @restrict
 function checkActionAccess(action, user) {
   const requires = action['@requires']
-  if (!requires) return true
+  if (requires) return _matchesToRoles(requires, user)
 
-  const roles = Array.isArray(requires) ? requires : [requires]
-  for (const role of roles) {
-    if (role === 'any') return true
-    if (role === 'authenticated-user') {
-      if (user && user.id !== 'anonymous') return true
-      continue
-    }
-    if (user?.is?.(role)) return true
+  // @restrict on actions: grant is ignored (implicitly '*'), only 'to' applies
+  const restrict = action['@restrict']
+  if (restrict) {
+    return restrict.some(privilege => _matchesToRoles(privilege.to, user))
   }
-  return false
+
+  return true
 }
 
 // Filter actions/functions to only those the user can execute
@@ -65,32 +65,9 @@ function checkAuthorization(srv) {
 
   // Check service-level authorization (@requires)
   const requires = srv.definition?.['@requires']
-  if (requires) {
-    const roles = Array.isArray(requires) ? requires : [requires]
-    let serviceAuthorized = false
-
-    for (const role of roles) {
-      if (role === 'any') {
-        serviceAuthorized = true
-        break
-      }
-      if (role === 'authenticated-user') {
-        if (user && user.id !== 'anonymous') {
-          serviceAuthorized = true
-          break
-        }
-        continue
-      }
-      if (user?.is?.(role)) {
-        serviceAuthorized = true
-        break
-      }
-    }
-
-    if (!serviceAuthorized) {
-      const code = !user || user.id === 'anonymous' ? 401 : 403
-      return { error: { code, reason: 'service_authorization' } }
-    }
+  if (requires && !_matchesToRoles(requires, user)) {
+    const code = !user || user.id === 'anonymous' ? 401 : 403
+    return { error: { code, reason: 'service_authorization' } }
   }
 
   // Filter out composition-only autoexposed, draft, and @cds.api.ignore entities

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,15 +3,15 @@ const cds = require('@sap/cds')
 function _hasRole(user, role) {
   if (role === 'any') return true
   if (role === 'authenticated-user') return !!(user && user.id !== 'anonymous')
-  if (role === 'system-user') return !!(user?.is?.('system-user'))
-  return !!(user?.is?.(role))
+  if (role === 'system-user') return !!user?.is?.('system-user')
+  return !!user?.is?.(role)
 }
 
 function _matchesToRoles(toRoles, user) {
   // No 'to' clause means 'any' pseudo-role — all users including unauthenticated
   if (!toRoles) return true
   const roles = Array.isArray(toRoles) ? toRoles : [toRoles]
-  return roles.some(role => _hasRole(user, role))
+  return roles.some((role) => _hasRole(user, role))
 }
 
 function checkEntityReadAccess(entity, user) {
@@ -45,7 +45,7 @@ function checkActionAccess(action, user) {
   // @restrict on actions: grant is ignored (implicitly '*'), only 'to' applies
   const restrict = action['@restrict']
   if (restrict) {
-    return restrict.some(privilege => _matchesToRoles(privilege.to, user))
+    return restrict.some((privilege) => _matchesToRoles(privilege.to, user))
   }
 
   return true

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -14,6 +14,42 @@ function _matchesToRoles(toRoles, user) {
   return roles.some((role) => _hasRole(user, role))
 }
 
+// Service-level authorization aligned with CAP's HTTP protocol adapter
+//   - @requires on service: normalize to role array
+//   - @restrict on service: collect all 'to' roles across privileges
+//   - if that yields zero roles, fall through to env fallback:
+//       NODE_ENV === 'production' && cds.env.requires.auth.restrict_all_services !== false
+//         → ['authenticated-user']
+//       otherwise                 → no gate (public)
+function checkServiceAccess(srv, user) {
+  const def = srv?.definition || srv
+  const requires = def?.['@requires']
+  const restrict = def?.['@restrict']
+
+  let declaredRoles
+  if (requires != null) {
+    declaredRoles = Array.isArray(requires) ? requires : [requires]
+  } else if (restrict != null) {
+    declaredRoles = restrict
+      .map((r) => r.to)
+      .flat()
+      .filter(Boolean)
+  }
+
+  const roles = declaredRoles?.length
+    ? declaredRoles
+    : process.env.NODE_ENV === 'production' &&
+        cds.env.requires?.auth?.restrict_all_services !== false
+      ? ['authenticated-user']
+      : null
+
+  if (!roles) return { ok: true }
+  if (roles.some((role) => _hasRole(user, role))) return { ok: true }
+
+  const anonymous = !user || user.id === 'anonymous' || user._is_anonymous
+  return { ok: false, code: anonymous ? 401 : 403 }
+}
+
 function checkEntityReadAccess(entity, user) {
   // @requires on entity is shorthand for @restrict: [{ grant: '*', to: <roles> }]
   const requires = entity['@requires']
@@ -63,11 +99,9 @@ function getAccessibleActions(actions, user) {
 function checkAuthorization(srv) {
   const user = cds.context?.user
 
-  // Check service-level authorization (@requires)
-  const requires = srv.definition?.['@requires']
-  if (requires && !_matchesToRoles(requires, user)) {
-    const code = !user || user.id === 'anonymous' ? 401 : 403
-    return { error: { code, reason: 'service_authorization' } }
+  const serviceCheck = checkServiceAccess(srv, user)
+  if (!serviceCheck.ok) {
+    return { error: { code: serviceCheck.code, reason: 'service_authorization' } }
   }
 
   // Filter out composition-only autoexposed, draft, and @cds.api.ignore entities
@@ -107,5 +141,6 @@ module.exports = {
   getAccessibleEntities,
   checkActionAccess,
   getAccessibleActions,
+  checkServiceAccess,
   checkAuthorization
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/mcp",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "CAP plugin to expose services as MCP servers for AI agent consumption",
   "repository": "cap-js/mcp",
   "files": [

--- a/tests/bookshop/srv/auth-test-service.cds
+++ b/tests/bookshop/srv/auth-test-service.cds
@@ -1,0 +1,79 @@
+using {sap.capire.bookshop as my} from '../db/schema';
+
+/**
+ * Service for testing all @requires / @restrict annotation combinations.
+ * Exposed via both @odata and @mcp so results can be compared directly.
+ */
+@odata
+@mcp
+service AuthTestService {
+  // --- entity-level @requires ---
+  // @requires: 'admin'  ≡  @restrict: [{ grant: '*', to: 'admin' }]
+  entity RequiresAdmin  as projection on my.Books   { ID, title, stock } where ID < 1000;
+
+  // @requires with multiple roles (OR logic) — admin OR editor
+  entity RequiresAdminOrEditor as projection on my.Authors { ID, name };
+
+  // --- entity-level @restrict with explicit READ grant ---
+  entity RestrictReadAdmin   as projection on my.Books   { ID, title, stock } where ID < 1000;
+  entity RestrictReadEditor  as projection on my.Authors { ID, name };
+
+  // @restrict with wildcard grant '*'
+  entity RestrictStarAdmin   as projection on my.Books   { ID, title, stock } where ID < 1000;
+
+  // @restrict with WRITE-only grant — READ has no explicit grant, so READ is denied (CAP behaviour:
+  // any @restrict annotation locks down access; only explicitly granted operations are allowed)
+  entity RestrictWriteAdmin  as projection on my.Books   { ID, title, stock } where ID < 1000;
+
+  // @restrict with no 'to' clause — 'any' pseudo-role, accessible to everyone incl. unauthenticated
+  entity RestrictNoTo        as projection on my.Genres  { ID, name };
+
+  // @restrict with multiple roles in one privilege
+  entity RestrictMultiRole   as projection on my.Books   { ID, title, stock } where ID < 1000;
+
+  // @restrict with multiple privileges (admin READ or editor READ)
+  entity RestrictMultiPrivilege as projection on my.Authors { ID, name };
+
+  // Both @requires (admin) AND @restrict (editor READ) — @requires wins because it is checked first
+  // and is shorthand for grant:* — an entity has either @requires or @restrict, not both
+  // (testing @requires alone is sufficient; this entity tests that @requires gates correctly)
+  entity RequiresAndRestrictAdmin as projection on my.Books { ID, title, stock } where ID < 1000;
+
+  // --- action-level @requires ---
+  @description: 'Admin-only action'
+  action adminAction(x: Integer) returns Integer;
+
+  @description: 'Editor-only action'
+  action editorAction(x: Integer) returns Integer;
+
+  @description: 'Open action (no auth)'
+  action openAction(x: Integer) returns Integer;
+
+  // --- action-level @restrict ---
+  @description: 'Action restricted via @restrict to admin'
+  action restrictedAction(x: Integer) returns Integer;
+}
+
+// entity-level @requires
+annotate AuthTestService.RequiresAdmin with @(requires: 'admin');
+annotate AuthTestService.RequiresAdminOrEditor with @(requires: ['admin', 'editor']);
+
+// entity-level @restrict
+annotate AuthTestService.RestrictReadAdmin with @(restrict: [{ grant: 'READ', to: 'admin' }]);
+annotate AuthTestService.RestrictReadEditor with @(restrict: [{ grant: 'READ', to: 'editor' }]);
+annotate AuthTestService.RestrictStarAdmin with @(restrict: [{ grant: '*', to: 'admin' }]);
+annotate AuthTestService.RestrictWriteAdmin with @(restrict: [{ grant: 'WRITE', to: 'admin' }]);
+annotate AuthTestService.RestrictNoTo with @(restrict: [{ grant: 'READ' }]);
+annotate AuthTestService.RestrictMultiRole with @(restrict: [{ grant: 'READ', to: ['admin', 'editor'] }]);
+annotate AuthTestService.RestrictMultiPrivilege with @(restrict: [
+  { grant: 'READ', to: 'admin' },
+  { grant: 'READ', to: 'editor' }
+]);
+annotate AuthTestService.RequiresAndRestrictAdmin with @(requires: 'admin');
+
+// action-level @requires
+annotate AuthTestService.adminAction with @(requires: 'admin');
+annotate AuthTestService.editorAction with @(requires: 'editor');
+
+// action-level @restrict (grant is ignored on actions, only 'to' matters)
+annotate AuthTestService.restrictedAction with @(restrict: [{ grant: 'READ', to: 'admin' }]);

--- a/tests/bookshop/srv/auth-test-service.js
+++ b/tests/bookshop/srv/auth-test-service.js
@@ -1,0 +1,6 @@
+module.exports = function AuthTestService(srv) {
+  srv.on('adminAction', (req) => req.data.x || 0)
+  srv.on('editorAction', (req) => req.data.x || 0)
+  srv.on('openAction', (req) => req.data.x || 0)
+  srv.on('restrictedAction', (req) => req.data.x || 0)
+}

--- a/tests/bookshop/srv/service-auth-test.cds
+++ b/tests/bookshop/srv/service-auth-test.cds
@@ -1,0 +1,39 @@
+using {sap.capire.bookshop as my} from '../db/schema';
+
+/**
+ * Service-level authorization test services.
+ * Each service annotates its own definition (not entities) so we can verify
+ * service-level @requires / @restrict enforcement mirroring CAP's HTTP
+ * `authorize` semantics (dev = public / prod = 'authenticated-user' when
+ * @restrict clauses carry no `to`).
+ *
+ * Each is exposed via both @odata and @mcp for parity checks.
+ */
+
+@odata
+@mcp
+@requires: 'admin'
+service ServiceRequiresAdmin {
+  entity Books as projection on my.Books { ID, title } where ID < 1000;
+}
+
+@odata
+@mcp
+@restrict: [{ grant: 'READ', to: 'admin' }]
+service ServiceRestrictAdmin {
+  entity Books as projection on my.Books { ID, title } where ID < 1000;
+}
+
+@odata
+@mcp
+@restrict: [{ grant: 'READ' }] // no `to` — falls to CAP env fallback
+service ServiceRestrictNoTo {
+  entity Books as projection on my.Books { ID, title } where ID < 1000;
+}
+
+@odata
+@mcp
+@restrict: [{ grant: 'READ', to: ['admin', 'editor'] }]
+service ServiceRestrictAdminOrEditor {
+  entity Books as projection on my.Books { ID, title } where ID < 1000;
+}

--- a/tests/integration/auth-combinations.test.js
+++ b/tests/integration/auth-combinations.test.js
@@ -74,7 +74,7 @@ describe('@requires on entity', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('alice:'),
         odataGet('RequiresAdmin', 'alice:'),
-        mcpQuery('RequiresAdmin', 'alice:'),
+        mcpQuery('RequiresAdmin', 'alice:')
       ])
       expect(entities).to.include('RequiresAdmin')
       expect(odataStatus).to.equal(200)
@@ -85,7 +85,7 @@ describe('@requires on entity', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('eve:'),
         odataGet('RequiresAdmin', 'eve:'),
-        mcpCqlQuery('RequiresAdmin', 'eve:'),
+        mcpCqlQuery('RequiresAdmin', 'eve:')
       ])
       expect(entities).to.not.include('RequiresAdmin')
       expect(odataStatus).to.equal(403)
@@ -96,7 +96,7 @@ describe('@requires on entity', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('bob:'),
         odataGet('RequiresAdmin', 'bob:'),
-        mcpCqlQuery('RequiresAdmin', 'bob:'),
+        mcpCqlQuery('RequiresAdmin', 'bob:')
       ])
       expect(entities).to.not.include('RequiresAdmin')
       expect(odataStatus).to.equal(403)
@@ -107,7 +107,7 @@ describe('@requires on entity', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum(null),
         odataGet('RequiresAdmin', null),
-        mcpCqlQuery('RequiresAdmin', null),
+        mcpCqlQuery('RequiresAdmin', null)
       ])
       expect(entities).to.not.include('RequiresAdmin')
       expect(odataStatus).to.equal(401)
@@ -120,7 +120,7 @@ describe('@requires on entity', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('alice:'),
         odataGet('RequiresAdminOrEditor', 'alice:'),
-        mcpQuery('RequiresAdminOrEditor', 'alice:'),
+        mcpQuery('RequiresAdminOrEditor', 'alice:')
       ])
       expect(entities).to.include('RequiresAdminOrEditor')
       expect(odataStatus).to.equal(200)
@@ -131,7 +131,7 @@ describe('@requires on entity', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('eve:'),
         odataGet('RequiresAdminOrEditor', 'eve:'),
-        mcpQuery('RequiresAdminOrEditor', 'eve:'),
+        mcpQuery('RequiresAdminOrEditor', 'eve:')
       ])
       expect(entities).to.include('RequiresAdminOrEditor')
       expect(odataStatus).to.equal(200)
@@ -142,7 +142,7 @@ describe('@requires on entity', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('bob:'),
         odataGet('RequiresAdminOrEditor', 'bob:'),
-        mcpCqlQuery('RequiresAdminOrEditor', 'bob:'),
+        mcpCqlQuery('RequiresAdminOrEditor', 'bob:')
       ])
       expect(entities).to.not.include('RequiresAdminOrEditor')
       expect(odataStatus).to.equal(403)
@@ -153,7 +153,7 @@ describe('@requires on entity', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum(null),
         odataGet('RequiresAdminOrEditor', null),
-        mcpCqlQuery('RequiresAdminOrEditor', null),
+        mcpCqlQuery('RequiresAdminOrEditor', null)
       ])
       expect(entities).to.not.include('RequiresAdminOrEditor')
       expect(odataStatus).to.equal(401)
@@ -170,7 +170,7 @@ describe('@restrict: [{ grant: "READ", to: role }]', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('alice:'),
         odataGet('RestrictReadAdmin', 'alice:'),
-        mcpQuery('RestrictReadAdmin', 'alice:'),
+        mcpQuery('RestrictReadAdmin', 'alice:')
       ])
       expect(entities).to.include('RestrictReadAdmin')
       expect(odataStatus).to.equal(200)
@@ -181,7 +181,7 @@ describe('@restrict: [{ grant: "READ", to: role }]', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('eve:'),
         odataGet('RestrictReadAdmin', 'eve:'),
-        mcpCqlQuery('RestrictReadAdmin', 'eve:'),
+        mcpCqlQuery('RestrictReadAdmin', 'eve:')
       ])
       expect(entities).to.not.include('RestrictReadAdmin')
       expect(odataStatus).to.equal(403)
@@ -192,7 +192,7 @@ describe('@restrict: [{ grant: "READ", to: role }]', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum(null),
         odataGet('RestrictReadAdmin', null),
-        mcpCqlQuery('RestrictReadAdmin', null),
+        mcpCqlQuery('RestrictReadAdmin', null)
       ])
       expect(entities).to.not.include('RestrictReadAdmin')
       expect(odataStatus).to.equal(401)
@@ -205,7 +205,7 @@ describe('@restrict: [{ grant: "READ", to: role }]', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('eve:'),
         odataGet('RestrictReadEditor', 'eve:'),
-        mcpQuery('RestrictReadEditor', 'eve:'),
+        mcpQuery('RestrictReadEditor', 'eve:')
       ])
       expect(entities).to.include('RestrictReadEditor')
       expect(odataStatus).to.equal(200)
@@ -216,7 +216,7 @@ describe('@restrict: [{ grant: "READ", to: role }]', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum('alice:'),
         odataGet('RestrictReadEditor', 'alice:'),
-        mcpCqlQuery('RestrictReadEditor', 'alice:'),
+        mcpCqlQuery('RestrictReadEditor', 'alice:')
       ])
       expect(entities).to.not.include('RestrictReadEditor')
       expect(odataStatus).to.equal(403)
@@ -227,7 +227,7 @@ describe('@restrict: [{ grant: "READ", to: role }]', () => {
       const [entities, odataStatus, mcpError] = await Promise.all([
         getMcpEntityEnum(null),
         odataGet('RestrictReadEditor', null),
-        mcpCqlQuery('RestrictReadEditor', null),
+        mcpCqlQuery('RestrictReadEditor', null)
       ])
       expect(entities).to.not.include('RestrictReadEditor')
       expect(odataStatus).to.equal(401)
@@ -243,7 +243,7 @@ describe('@restrict: [{ grant: "*", to: "admin" }]', () => {
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('alice:'),
       odataGet('RestrictStarAdmin', 'alice:'),
-      mcpQuery('RestrictStarAdmin', 'alice:'),
+      mcpQuery('RestrictStarAdmin', 'alice:')
     ])
     expect(entities).to.include('RestrictStarAdmin')
     expect(odataStatus).to.equal(200)
@@ -254,7 +254,7 @@ describe('@restrict: [{ grant: "*", to: "admin" }]', () => {
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('eve:'),
       odataGet('RestrictStarAdmin', 'eve:'),
-      mcpCqlQuery('RestrictStarAdmin', 'eve:'),
+      mcpCqlQuery('RestrictStarAdmin', 'eve:')
     ])
     expect(entities).to.not.include('RestrictStarAdmin')
     expect(odataStatus).to.equal(403)
@@ -265,7 +265,7 @@ describe('@restrict: [{ grant: "*", to: "admin" }]', () => {
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum(null),
       odataGet('RestrictStarAdmin', null),
-      mcpCqlQuery('RestrictStarAdmin', null),
+      mcpCqlQuery('RestrictStarAdmin', null)
     ])
     expect(entities).to.not.include('RestrictStarAdmin')
     expect(odataStatus).to.equal(401)
@@ -280,7 +280,7 @@ describe('@restrict: [{ grant: "WRITE", to: "admin" }] — no READ grant, READ d
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('alice:'),
       odataGet('RestrictWriteAdmin', 'alice:'),
-      mcpCqlQuery('RestrictWriteAdmin', 'alice:'),
+      mcpCqlQuery('RestrictWriteAdmin', 'alice:')
     ])
     expect(entities).to.not.include('RestrictWriteAdmin')
     expect(odataStatus).to.equal(403)
@@ -291,7 +291,7 @@ describe('@restrict: [{ grant: "WRITE", to: "admin" }] — no READ grant, READ d
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('eve:'),
       odataGet('RestrictWriteAdmin', 'eve:'),
-      mcpCqlQuery('RestrictWriteAdmin', 'eve:'),
+      mcpCqlQuery('RestrictWriteAdmin', 'eve:')
     ])
     expect(entities).to.not.include('RestrictWriteAdmin')
     expect(odataStatus).to.equal(403)
@@ -302,7 +302,7 @@ describe('@restrict: [{ grant: "WRITE", to: "admin" }] — no READ grant, READ d
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum(null),
       odataGet('RestrictWriteAdmin', null),
-      mcpCqlQuery('RestrictWriteAdmin', null),
+      mcpCqlQuery('RestrictWriteAdmin', null)
     ])
     expect(entities).to.not.include('RestrictWriteAdmin')
     expect(odataStatus).to.equal(401)
@@ -317,7 +317,7 @@ describe('@restrict: [{ grant: "READ" }] — no "to", defaults to "any"', () => 
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('alice:'),
       odataGet('RestrictNoTo', 'alice:'),
-      mcpQuery('RestrictNoTo', 'alice:'),
+      mcpQuery('RestrictNoTo', 'alice:')
     ])
     expect(entities).to.include('RestrictNoTo')
     expect(odataStatus).to.equal(200)
@@ -328,7 +328,7 @@ describe('@restrict: [{ grant: "READ" }] — no "to", defaults to "any"', () => 
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('bob:'),
       odataGet('RestrictNoTo', 'bob:'),
-      mcpQuery('RestrictNoTo', 'bob:'),
+      mcpQuery('RestrictNoTo', 'bob:')
     ])
     expect(entities).to.include('RestrictNoTo')
     expect(odataStatus).to.equal(200)
@@ -339,7 +339,7 @@ describe('@restrict: [{ grant: "READ" }] — no "to", defaults to "any"', () => 
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum(null),
       odataGet('RestrictNoTo', null),
-      mcpQuery('RestrictNoTo', null),
+      mcpQuery('RestrictNoTo', null)
     ])
     expect(entities).to.include('RestrictNoTo')
     expect(odataStatus).to.equal(200)
@@ -354,7 +354,7 @@ describe('@restrict: [{ grant: "READ", to: ["admin", "editor"] }]', () => {
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('alice:'),
       odataGet('RestrictMultiRole', 'alice:'),
-      mcpQuery('RestrictMultiRole', 'alice:'),
+      mcpQuery('RestrictMultiRole', 'alice:')
     ])
     expect(entities).to.include('RestrictMultiRole')
     expect(odataStatus).to.equal(200)
@@ -365,7 +365,7 @@ describe('@restrict: [{ grant: "READ", to: ["admin", "editor"] }]', () => {
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('eve:'),
       odataGet('RestrictMultiRole', 'eve:'),
-      mcpQuery('RestrictMultiRole', 'eve:'),
+      mcpQuery('RestrictMultiRole', 'eve:')
     ])
     expect(entities).to.include('RestrictMultiRole')
     expect(odataStatus).to.equal(200)
@@ -376,7 +376,7 @@ describe('@restrict: [{ grant: "READ", to: ["admin", "editor"] }]', () => {
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('bob:'),
       odataGet('RestrictMultiRole', 'bob:'),
-      mcpCqlQuery('RestrictMultiRole', 'bob:'),
+      mcpCqlQuery('RestrictMultiRole', 'bob:')
     ])
     expect(entities).to.not.include('RestrictMultiRole')
     expect(odataStatus).to.equal(403)
@@ -387,7 +387,7 @@ describe('@restrict: [{ grant: "READ", to: ["admin", "editor"] }]', () => {
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum(null),
       odataGet('RestrictMultiRole', null),
-      mcpCqlQuery('RestrictMultiRole', null),
+      mcpCqlQuery('RestrictMultiRole', null)
     ])
     expect(entities).to.not.include('RestrictMultiRole')
     expect(odataStatus).to.equal(401)
@@ -402,7 +402,7 @@ describe('@restrict: [{ grant:"READ", to:"admin" }, { grant:"READ", to:"editor" 
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('alice:'),
       odataGet('RestrictMultiPrivilege', 'alice:'),
-      mcpQuery('RestrictMultiPrivilege', 'alice:'),
+      mcpQuery('RestrictMultiPrivilege', 'alice:')
     ])
     expect(entities).to.include('RestrictMultiPrivilege')
     expect(odataStatus).to.equal(200)
@@ -413,7 +413,7 @@ describe('@restrict: [{ grant:"READ", to:"admin" }, { grant:"READ", to:"editor" 
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('eve:'),
       odataGet('RestrictMultiPrivilege', 'eve:'),
-      mcpQuery('RestrictMultiPrivilege', 'eve:'),
+      mcpQuery('RestrictMultiPrivilege', 'eve:')
     ])
     expect(entities).to.include('RestrictMultiPrivilege')
     expect(odataStatus).to.equal(200)
@@ -424,7 +424,7 @@ describe('@restrict: [{ grant:"READ", to:"admin" }, { grant:"READ", to:"editor" 
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum('viewer:'),
       odataGet('RestrictMultiPrivilege', 'viewer:'),
-      mcpCqlQuery('RestrictMultiPrivilege', 'viewer:'),
+      mcpCqlQuery('RestrictMultiPrivilege', 'viewer:')
     ])
     expect(entities).to.not.include('RestrictMultiPrivilege')
     expect(odataStatus).to.equal(403)
@@ -435,7 +435,7 @@ describe('@restrict: [{ grant:"READ", to:"admin" }, { grant:"READ", to:"editor" 
     const [entities, odataStatus, mcpError] = await Promise.all([
       getMcpEntityEnum(null),
       odataGet('RestrictMultiPrivilege', null),
-      mcpCqlQuery('RestrictMultiPrivilege', null),
+      mcpCqlQuery('RestrictMultiPrivilege', null)
     ])
     expect(entities).to.not.include('RestrictMultiPrivilege')
     expect(odataStatus).to.equal(401)
@@ -461,7 +461,7 @@ describe('RequiresAndRestrictAdmin — @requires: "admin" (cross-check with Rest
   it('alice: OData status matches between @requires and @restrict[grant:"*"]', async () => {
     const [r1, r2] = await Promise.all([
       odataGet('RequiresAndRestrictAdmin', 'alice:'),
-      odataGet('RestrictStarAdmin', 'alice:'),
+      odataGet('RestrictStarAdmin', 'alice:')
     ])
     expect(r1).to.equal(r2).and.equal(200)
   })
@@ -469,7 +469,7 @@ describe('RequiresAndRestrictAdmin — @requires: "admin" (cross-check with Rest
   it('bob: OData status matches between @requires and @restrict[grant:"*"]', async () => {
     const [r1, r2] = await Promise.all([
       odataGet('RequiresAndRestrictAdmin', 'bob:'),
-      odataGet('RestrictStarAdmin', 'bob:'),
+      odataGet('RestrictStarAdmin', 'bob:')
     ])
     expect(r1).to.equal(r2).and.equal(403)
   })
@@ -477,7 +477,7 @@ describe('RequiresAndRestrictAdmin — @requires: "admin" (cross-check with Rest
   it('unauthenticated: OData status matches between @requires and @restrict[grant:"*"]', async () => {
     const [r1, r2] = await Promise.all([
       odataGet('RequiresAndRestrictAdmin', null),
-      odataGet('RestrictStarAdmin', null),
+      odataGet('RestrictStarAdmin', null)
     ])
     expect(r1).to.equal(r2).and.equal(401)
   })
@@ -511,19 +511,37 @@ describe('@requires on actions', () => {
     })
 
     it('alice (admin): OData action call returns 200', async () => {
-      const headers = { Authorization: `Basic ${Buffer.from('alice:').toString('base64')}`, 'Content-Type': 'application/json' }
-      const res = await fetch(`${test.url}${ODATA}/adminAction`, { method: 'POST', headers, body: JSON.stringify({ x: 1 }) })
+      const headers = {
+        Authorization: `Basic ${Buffer.from('alice:').toString('base64')}`,
+        'Content-Type': 'application/json'
+      }
+      const res = await fetch(`${test.url}${ODATA}/adminAction`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ x: 1 })
+      })
       expect(res.status).to.equal(200)
     })
 
     it('bob (no roles): OData action call returns 403', async () => {
-      const headers = { Authorization: `Basic ${Buffer.from('bob:').toString('base64')}`, 'Content-Type': 'application/json' }
-      const res = await fetch(`${test.url}${ODATA}/adminAction`, { method: 'POST', headers, body: JSON.stringify({ x: 1 }) })
+      const headers = {
+        Authorization: `Basic ${Buffer.from('bob:').toString('base64')}`,
+        'Content-Type': 'application/json'
+      }
+      const res = await fetch(`${test.url}${ODATA}/adminAction`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ x: 1 })
+      })
       expect(res.status).to.equal(403)
     })
 
     it('unauthenticated: OData action call returns 401', async () => {
-      const res = await fetch(`${test.url}${ODATA}/adminAction`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ x: 1 }) })
+      const res = await fetch(`${test.url}${ODATA}/adminAction`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ x: 1 })
+      })
       expect(res.status).to.equal(401)
     })
   })
@@ -581,14 +599,28 @@ describe('@restrict on actions (grant ignored, only "to" enforced)', () => {
     })
 
     it('alice (admin): OData action call returns 200', async () => {
-      const headers = { Authorization: `Basic ${Buffer.from('alice:').toString('base64')}`, 'Content-Type': 'application/json' }
-      const res = await fetch(`${test.url}${ODATA}/restrictedAction`, { method: 'POST', headers, body: JSON.stringify({ x: 1 }) })
+      const headers = {
+        Authorization: `Basic ${Buffer.from('alice:').toString('base64')}`,
+        'Content-Type': 'application/json'
+      }
+      const res = await fetch(`${test.url}${ODATA}/restrictedAction`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ x: 1 })
+      })
       expect(res.status).to.equal(200)
     })
 
     it('eve (editor): OData action call returns 403', async () => {
-      const headers = { Authorization: `Basic ${Buffer.from('eve:').toString('base64')}`, 'Content-Type': 'application/json' }
-      const res = await fetch(`${test.url}${ODATA}/restrictedAction`, { method: 'POST', headers, body: JSON.stringify({ x: 1 }) })
+      const headers = {
+        Authorization: `Basic ${Buffer.from('eve:').toString('base64')}`,
+        'Content-Type': 'application/json'
+      }
+      const res = await fetch(`${test.url}${ODATA}/restrictedAction`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ x: 1 })
+      })
       expect(res.status).to.equal(403)
     })
   })

--- a/tests/integration/auth-combinations.test.js
+++ b/tests/integration/auth-combinations.test.js
@@ -1,0 +1,615 @@
+/**
+ * Comprehensive authorization tests for @requires and @restrict annotation combinations.
+ *
+ * Each test verifies both MCP (tools/list entity enum + query access) and OData (HTTP GET)
+ * to confirm the two surfaces enforce permissions identically.
+ *
+ * Users:
+ *   alice   — roles: [admin]         (CDS built-in)
+ *   eve     — roles: [editor]        (added in bookshop/package.json)
+ *   viewer  — roles: [viewer]        (added in bookshop/package.json — no matching role)
+ *   bob     — roles: []              (CDS built-in — no relevant roles)
+ *   <none>  — unauthenticated
+ */
+const cds = require('@sap/cds')
+cds.env.mcp ??= {}
+cds.env.mcp.format = 'cqn'
+// Add users with roles not present in the CDS default mock users
+cds.env.requires ??= {}
+cds.env.requires.auth ??= {}
+cds.env.requires.auth.users ??= {}
+cds.env.requires.auth.users.eve = { roles: ['editor'] }
+cds.env.requires.auth.users.viewer = { roles: ['viewer'] }
+const test = cds.test(__dirname + '/../bookshop')
+const { expect } = test
+const mcpClient = require('./mcp-test-client')(test)
+
+const MCP = '/mcp/auth-test'
+const ODATA = '/odata/v4/auth-test'
+
+// Helper: MCP entity enum from tools/list
+async function getMcpEntityEnum(auth) {
+  const { mcp } = mcpClient(MCP, auth)
+  const res = await mcp('tools/list')
+  const queryTool = res.result?.tools?.find((t) => t.name === 'query')
+  return queryTool?.inputSchema?.properties?.entity?.enum ?? []
+}
+
+// Helper: MCP action enum from tools/list
+async function getMcpActionEnum(auth) {
+  const { mcp } = mcpClient(MCP, auth)
+  const res = await mcp('tools/list')
+  const callTool = res.result?.tools?.find((t) => t.name === 'call')
+  return callTool?.inputSchema?.properties?.action?.enum ?? null // null = no call tool
+}
+
+// Helper: OData GET — returns HTTP status
+async function odataGet(entity, auth) {
+  const headers = { Accept: 'application/json' }
+  if (auth) headers['Authorization'] = `Basic ${Buffer.from(auth).toString('base64')}`
+  const res = await fetch(`${test.url}${ODATA}/${entity}`, { headers })
+  return res.status
+}
+
+// Helper: MCP query — returns null on success, error string on failure
+async function mcpQuery(entity, auth) {
+  const { callTool } = mcpClient(MCP, auth)
+  const { error } = await callTool('query', { entity })
+  return error
+}
+
+// Helper: MCP CQL query — issues SELECT from entity, returns null on success, error string on failure
+// Used to verify auth is enforced at query-time even when the entity is not in the enum
+async function mcpCqlQuery(entity, auth) {
+  const { callTool } = mcpClient(MCP, auth)
+  const { error } = await callTool('query', { cql: `SELECT * FROM ${entity}` })
+  return error
+}
+
+// ─── @requires on entity ─────────────────────────────────────────────────────
+
+describe('@requires on entity', () => {
+  describe('RequiresAdmin — @requires: "admin"', () => {
+    it('alice (admin): visible in MCP, readable via OData', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('alice:'),
+        odataGet('RequiresAdmin', 'alice:'),
+        mcpQuery('RequiresAdmin', 'alice:'),
+      ])
+      expect(entities).to.include('RequiresAdmin')
+      expect(odataStatus).to.equal(200)
+      expect(mcpError).to.be.null
+    })
+
+    it('eve (editor): NOT visible in MCP, 403 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('eve:'),
+        odataGet('RequiresAdmin', 'eve:'),
+        mcpCqlQuery('RequiresAdmin', 'eve:'),
+      ])
+      expect(entities).to.not.include('RequiresAdmin')
+      expect(odataStatus).to.equal(403)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+
+    it('bob (no roles): NOT visible in MCP, 403 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('bob:'),
+        odataGet('RequiresAdmin', 'bob:'),
+        mcpCqlQuery('RequiresAdmin', 'bob:'),
+      ])
+      expect(entities).to.not.include('RequiresAdmin')
+      expect(odataStatus).to.equal(403)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+
+    it('unauthenticated: NOT visible in MCP, 401 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum(null),
+        odataGet('RequiresAdmin', null),
+        mcpCqlQuery('RequiresAdmin', null),
+      ])
+      expect(entities).to.not.include('RequiresAdmin')
+      expect(odataStatus).to.equal(401)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+  })
+
+  describe('RequiresAdminOrEditor — @requires: ["admin", "editor"]', () => {
+    it('alice (admin): visible in MCP, readable via OData', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('alice:'),
+        odataGet('RequiresAdminOrEditor', 'alice:'),
+        mcpQuery('RequiresAdminOrEditor', 'alice:'),
+      ])
+      expect(entities).to.include('RequiresAdminOrEditor')
+      expect(odataStatus).to.equal(200)
+      expect(mcpError).to.be.null
+    })
+
+    it('eve (editor): visible in MCP, readable via OData', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('eve:'),
+        odataGet('RequiresAdminOrEditor', 'eve:'),
+        mcpQuery('RequiresAdminOrEditor', 'eve:'),
+      ])
+      expect(entities).to.include('RequiresAdminOrEditor')
+      expect(odataStatus).to.equal(200)
+      expect(mcpError).to.be.null
+    })
+
+    it('bob (no roles): NOT visible in MCP, 403 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('bob:'),
+        odataGet('RequiresAdminOrEditor', 'bob:'),
+        mcpCqlQuery('RequiresAdminOrEditor', 'bob:'),
+      ])
+      expect(entities).to.not.include('RequiresAdminOrEditor')
+      expect(odataStatus).to.equal(403)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+
+    it('unauthenticated: NOT visible in MCP, 401 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum(null),
+        odataGet('RequiresAdminOrEditor', null),
+        mcpCqlQuery('RequiresAdminOrEditor', null),
+      ])
+      expect(entities).to.not.include('RequiresAdminOrEditor')
+      expect(odataStatus).to.equal(401)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+  })
+})
+
+// ─── @restrict with explicit READ grant ──────────────────────────────────────
+
+describe('@restrict: [{ grant: "READ", to: role }]', () => {
+  describe('RestrictReadAdmin — to: "admin"', () => {
+    it('alice (admin): visible in MCP, readable via OData', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('alice:'),
+        odataGet('RestrictReadAdmin', 'alice:'),
+        mcpQuery('RestrictReadAdmin', 'alice:'),
+      ])
+      expect(entities).to.include('RestrictReadAdmin')
+      expect(odataStatus).to.equal(200)
+      expect(mcpError).to.be.null
+    })
+
+    it('eve (editor): NOT visible in MCP, 403 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('eve:'),
+        odataGet('RestrictReadAdmin', 'eve:'),
+        mcpCqlQuery('RestrictReadAdmin', 'eve:'),
+      ])
+      expect(entities).to.not.include('RestrictReadAdmin')
+      expect(odataStatus).to.equal(403)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+
+    it('unauthenticated: NOT visible in MCP, 401 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum(null),
+        odataGet('RestrictReadAdmin', null),
+        mcpCqlQuery('RestrictReadAdmin', null),
+      ])
+      expect(entities).to.not.include('RestrictReadAdmin')
+      expect(odataStatus).to.equal(401)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+  })
+
+  describe('RestrictReadEditor — to: "editor"', () => {
+    it('eve (editor): visible in MCP, readable via OData', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('eve:'),
+        odataGet('RestrictReadEditor', 'eve:'),
+        mcpQuery('RestrictReadEditor', 'eve:'),
+      ])
+      expect(entities).to.include('RestrictReadEditor')
+      expect(odataStatus).to.equal(200)
+      expect(mcpError).to.be.null
+    })
+
+    it('alice (admin): NOT visible in MCP, 403 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum('alice:'),
+        odataGet('RestrictReadEditor', 'alice:'),
+        mcpCqlQuery('RestrictReadEditor', 'alice:'),
+      ])
+      expect(entities).to.not.include('RestrictReadEditor')
+      expect(odataStatus).to.equal(403)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+
+    it('unauthenticated: NOT visible in MCP, 401 from OData, query rejected', async () => {
+      const [entities, odataStatus, mcpError] = await Promise.all([
+        getMcpEntityEnum(null),
+        odataGet('RestrictReadEditor', null),
+        mcpCqlQuery('RestrictReadEditor', null),
+      ])
+      expect(entities).to.not.include('RestrictReadEditor')
+      expect(odataStatus).to.equal(401)
+      expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+    })
+  })
+})
+
+// ─── @restrict with wildcard grant '*' ───────────────────────────────────────
+
+describe('@restrict: [{ grant: "*", to: "admin" }]', () => {
+  it('alice (admin): visible in MCP, readable via OData', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('alice:'),
+      odataGet('RestrictStarAdmin', 'alice:'),
+      mcpQuery('RestrictStarAdmin', 'alice:'),
+    ])
+    expect(entities).to.include('RestrictStarAdmin')
+    expect(odataStatus).to.equal(200)
+    expect(mcpError).to.be.null
+  })
+
+  it('eve (editor): NOT visible in MCP, 403 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('eve:'),
+      odataGet('RestrictStarAdmin', 'eve:'),
+      mcpCqlQuery('RestrictStarAdmin', 'eve:'),
+    ])
+    expect(entities).to.not.include('RestrictStarAdmin')
+    expect(odataStatus).to.equal(403)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+
+  it('unauthenticated: NOT visible in MCP, 401 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum(null),
+      odataGet('RestrictStarAdmin', null),
+      mcpCqlQuery('RestrictStarAdmin', null),
+    ])
+    expect(entities).to.not.include('RestrictStarAdmin')
+    expect(odataStatus).to.equal(401)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+})
+
+// ─── @restrict WRITE-only (no READ grant) ────────────────────────────────────
+
+describe('@restrict: [{ grant: "WRITE", to: "admin" }] — no READ grant, READ denied for all', () => {
+  it('alice (admin): NOT visible in MCP, 403 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('alice:'),
+      odataGet('RestrictWriteAdmin', 'alice:'),
+      mcpCqlQuery('RestrictWriteAdmin', 'alice:'),
+    ])
+    expect(entities).to.not.include('RestrictWriteAdmin')
+    expect(odataStatus).to.equal(403)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+
+  it('eve (editor): NOT visible in MCP, 403 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('eve:'),
+      odataGet('RestrictWriteAdmin', 'eve:'),
+      mcpCqlQuery('RestrictWriteAdmin', 'eve:'),
+    ])
+    expect(entities).to.not.include('RestrictWriteAdmin')
+    expect(odataStatus).to.equal(403)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+
+  it('unauthenticated: NOT visible in MCP, 401 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum(null),
+      odataGet('RestrictWriteAdmin', null),
+      mcpCqlQuery('RestrictWriteAdmin', null),
+    ])
+    expect(entities).to.not.include('RestrictWriteAdmin')
+    expect(odataStatus).to.equal(401)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+})
+
+// ─── @restrict with no 'to' clause ───────────────────────────────────────────
+
+describe('@restrict: [{ grant: "READ" }] — no "to", defaults to "any"', () => {
+  it('alice (admin): visible in MCP, readable via OData', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('alice:'),
+      odataGet('RestrictNoTo', 'alice:'),
+      mcpQuery('RestrictNoTo', 'alice:'),
+    ])
+    expect(entities).to.include('RestrictNoTo')
+    expect(odataStatus).to.equal(200)
+    expect(mcpError).to.be.null
+  })
+
+  it('bob (no roles): visible in MCP, readable via OData', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('bob:'),
+      odataGet('RestrictNoTo', 'bob:'),
+      mcpQuery('RestrictNoTo', 'bob:'),
+    ])
+    expect(entities).to.include('RestrictNoTo')
+    expect(odataStatus).to.equal(200)
+    expect(mcpError).to.be.null
+  })
+
+  it('unauthenticated: visible in MCP, readable via OData', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum(null),
+      odataGet('RestrictNoTo', null),
+      mcpQuery('RestrictNoTo', null),
+    ])
+    expect(entities).to.include('RestrictNoTo')
+    expect(odataStatus).to.equal(200)
+    expect(mcpError).to.be.null
+  })
+})
+
+// ─── @restrict with multiple roles in one privilege ──────────────────────────
+
+describe('@restrict: [{ grant: "READ", to: ["admin", "editor"] }]', () => {
+  it('alice (admin): visible in MCP, readable via OData', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('alice:'),
+      odataGet('RestrictMultiRole', 'alice:'),
+      mcpQuery('RestrictMultiRole', 'alice:'),
+    ])
+    expect(entities).to.include('RestrictMultiRole')
+    expect(odataStatus).to.equal(200)
+    expect(mcpError).to.be.null
+  })
+
+  it('eve (editor): visible in MCP, readable via OData', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('eve:'),
+      odataGet('RestrictMultiRole', 'eve:'),
+      mcpQuery('RestrictMultiRole', 'eve:'),
+    ])
+    expect(entities).to.include('RestrictMultiRole')
+    expect(odataStatus).to.equal(200)
+    expect(mcpError).to.be.null
+  })
+
+  it('bob (no roles): NOT visible in MCP, 403 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('bob:'),
+      odataGet('RestrictMultiRole', 'bob:'),
+      mcpCqlQuery('RestrictMultiRole', 'bob:'),
+    ])
+    expect(entities).to.not.include('RestrictMultiRole')
+    expect(odataStatus).to.equal(403)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+
+  it('unauthenticated: NOT visible in MCP, 401 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum(null),
+      odataGet('RestrictMultiRole', null),
+      mcpCqlQuery('RestrictMultiRole', null),
+    ])
+    expect(entities).to.not.include('RestrictMultiRole')
+    expect(odataStatus).to.equal(401)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+})
+
+// ─── @restrict with multiple separate privileges ─────────────────────────────
+
+describe('@restrict: [{ grant:"READ", to:"admin" }, { grant:"READ", to:"editor" }]', () => {
+  it('alice (admin): visible in MCP, readable via OData', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('alice:'),
+      odataGet('RestrictMultiPrivilege', 'alice:'),
+      mcpQuery('RestrictMultiPrivilege', 'alice:'),
+    ])
+    expect(entities).to.include('RestrictMultiPrivilege')
+    expect(odataStatus).to.equal(200)
+    expect(mcpError).to.be.null
+  })
+
+  it('eve (editor): visible in MCP, readable via OData', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('eve:'),
+      odataGet('RestrictMultiPrivilege', 'eve:'),
+      mcpQuery('RestrictMultiPrivilege', 'eve:'),
+    ])
+    expect(entities).to.include('RestrictMultiPrivilege')
+    expect(odataStatus).to.equal(200)
+    expect(mcpError).to.be.null
+  })
+
+  it('viewer (unrelated role): NOT visible in MCP, 403 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum('viewer:'),
+      odataGet('RestrictMultiPrivilege', 'viewer:'),
+      mcpCqlQuery('RestrictMultiPrivilege', 'viewer:'),
+    ])
+    expect(entities).to.not.include('RestrictMultiPrivilege')
+    expect(odataStatus).to.equal(403)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+
+  it('unauthenticated: NOT visible in MCP, 401 from OData, query rejected', async () => {
+    const [entities, odataStatus, mcpError] = await Promise.all([
+      getMcpEntityEnum(null),
+      odataGet('RestrictMultiPrivilege', null),
+      mcpCqlQuery('RestrictMultiPrivilege', null),
+    ])
+    expect(entities).to.not.include('RestrictMultiPrivilege')
+    expect(odataStatus).to.equal(401)
+    expect(mcpError).to.match(/authoriz|not allowed|invalid/i)
+  })
+})
+
+// ─── @requires on entity (same result as @restrict [grant:'*']) ───────────────
+
+describe('RequiresAndRestrictAdmin — @requires: "admin" (cross-check with RestrictStarAdmin)', () => {
+  it('alice (admin): both entities visible in MCP', async () => {
+    const entities = await getMcpEntityEnum('alice:')
+    expect(entities).to.include('RequiresAndRestrictAdmin')
+    expect(entities).to.include('RestrictStarAdmin')
+  })
+
+  it('bob (no roles): neither entity visible in MCP', async () => {
+    const entities = await getMcpEntityEnum('bob:')
+    expect(entities).to.not.include('RequiresAndRestrictAdmin')
+    expect(entities).to.not.include('RestrictStarAdmin')
+  })
+
+  it('alice: OData status matches between @requires and @restrict[grant:"*"]', async () => {
+    const [r1, r2] = await Promise.all([
+      odataGet('RequiresAndRestrictAdmin', 'alice:'),
+      odataGet('RestrictStarAdmin', 'alice:'),
+    ])
+    expect(r1).to.equal(r2).and.equal(200)
+  })
+
+  it('bob: OData status matches between @requires and @restrict[grant:"*"]', async () => {
+    const [r1, r2] = await Promise.all([
+      odataGet('RequiresAndRestrictAdmin', 'bob:'),
+      odataGet('RestrictStarAdmin', 'bob:'),
+    ])
+    expect(r1).to.equal(r2).and.equal(403)
+  })
+
+  it('unauthenticated: OData status matches between @requires and @restrict[grant:"*"]', async () => {
+    const [r1, r2] = await Promise.all([
+      odataGet('RequiresAndRestrictAdmin', null),
+      odataGet('RestrictStarAdmin', null),
+    ])
+    expect(r1).to.equal(r2).and.equal(401)
+  })
+})
+
+// ─── @requires on actions ─────────────────────────────────────────────────────
+
+describe('@requires on actions', () => {
+  describe('adminAction — @requires: "admin"', () => {
+    it('alice (admin): action visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('alice:')
+      expect(actions).to.include('adminAction')
+    })
+
+    it('eve (editor): action NOT visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('eve:')
+      expect(actions).to.not.include('adminAction')
+    })
+
+    it('bob (no roles): action NOT visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('bob:')
+      expect(actions).to.not.include('adminAction')
+    })
+
+    it('unauthenticated: call tool present (openAction has no restriction)', async () => {
+      const actions = await getMcpActionEnum(null)
+      // openAction has no @requires/@restrict — visible to all including unauthenticated
+      expect(actions).to.include('openAction')
+      expect(actions).to.not.include('adminAction')
+      expect(actions).to.not.include('restrictedAction')
+    })
+
+    it('alice (admin): OData action call returns 200', async () => {
+      const headers = { Authorization: `Basic ${Buffer.from('alice:').toString('base64')}`, 'Content-Type': 'application/json' }
+      const res = await fetch(`${test.url}${ODATA}/adminAction`, { method: 'POST', headers, body: JSON.stringify({ x: 1 }) })
+      expect(res.status).to.equal(200)
+    })
+
+    it('bob (no roles): OData action call returns 403', async () => {
+      const headers = { Authorization: `Basic ${Buffer.from('bob:').toString('base64')}`, 'Content-Type': 'application/json' }
+      const res = await fetch(`${test.url}${ODATA}/adminAction`, { method: 'POST', headers, body: JSON.stringify({ x: 1 }) })
+      expect(res.status).to.equal(403)
+    })
+
+    it('unauthenticated: OData action call returns 401', async () => {
+      const res = await fetch(`${test.url}${ODATA}/adminAction`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ x: 1 }) })
+      expect(res.status).to.equal(401)
+    })
+  })
+
+  describe('editorAction — @requires: "editor"', () => {
+    it('eve (editor): action visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('eve:')
+      expect(actions).to.include('editorAction')
+    })
+
+    it('alice (admin): action NOT visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('alice:')
+      expect(actions).to.not.include('editorAction')
+    })
+  })
+
+  describe('openAction — no auth annotation', () => {
+    it('alice (admin): action visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('alice:')
+      expect(actions).to.include('openAction')
+    })
+
+    it('eve (editor): action visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('eve:')
+      expect(actions).to.include('openAction')
+    })
+
+    it('bob (no roles): action visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('bob:')
+      expect(actions).to.include('openAction')
+    })
+  })
+})
+
+// ─── @restrict on actions ─────────────────────────────────────────────────────
+
+describe('@restrict on actions (grant ignored, only "to" enforced)', () => {
+  describe('restrictedAction — @restrict: [{ grant: "READ", to: "admin" }]', () => {
+    it('alice (admin): action visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('alice:')
+      expect(actions).to.include('restrictedAction')
+    })
+
+    it('eve (editor): action NOT visible in MCP call tool', async () => {
+      const actions = await getMcpActionEnum('eve:')
+      expect(actions).to.not.include('restrictedAction')
+    })
+
+    it('unauthenticated: call tool present (openAction has no restriction)', async () => {
+      const actions = await getMcpActionEnum(null)
+      // openAction has no @requires/@restrict — visible to all including unauthenticated
+      expect(actions).to.include('openAction')
+      expect(actions).to.not.include('adminAction')
+      expect(actions).to.not.include('restrictedAction')
+    })
+
+    it('alice (admin): OData action call returns 200', async () => {
+      const headers = { Authorization: `Basic ${Buffer.from('alice:').toString('base64')}`, 'Content-Type': 'application/json' }
+      const res = await fetch(`${test.url}${ODATA}/restrictedAction`, { method: 'POST', headers, body: JSON.stringify({ x: 1 }) })
+      expect(res.status).to.equal(200)
+    })
+
+    it('eve (editor): OData action call returns 403', async () => {
+      const headers = { Authorization: `Basic ${Buffer.from('eve:').toString('base64')}`, 'Content-Type': 'application/json' }
+      const res = await fetch(`${test.url}${ODATA}/restrictedAction`, { method: 'POST', headers, body: JSON.stringify({ x: 1 }) })
+      expect(res.status).to.equal(403)
+    })
+  })
+})
+
+// ─── MCP call tool visibility rules ──────────────────────────────────────────
+
+describe('MCP call tool presence rules', () => {
+  it('call tool is absent when user has no accessible actions', async () => {
+    // bob has no roles → adminAction, editorAction, restrictedAction all hidden
+    // openAction has no auth → still visible → call tool should still appear
+    const actions = await getMcpActionEnum('bob:')
+    expect(actions).to.include('openAction')
+    expect(actions).to.not.include('adminAction')
+    expect(actions).to.not.include('editorAction')
+    expect(actions).to.not.include('restrictedAction')
+  })
+
+  it('call tool is present when unauthenticated but openAction has no restriction', async () => {
+    // unauthenticated: openAction is visible (no auth), so call tool should exist
+    const actions = await getMcpActionEnum(null)
+    expect(actions).to.include('openAction')
+  })
+})

--- a/tests/integration/auth-combinations.test.js
+++ b/tests/integration/auth-combinations.test.js
@@ -645,3 +645,213 @@ describe('MCP call tool presence rules', () => {
     expect(actions).to.include('openAction')
   })
 })
+
+// ─── Service-level @requires / @restrict ─────────────────────────────────────
+//
+// Mirrors CAP HTTP protocol adapter's `authorize` semantics
+// (@sap/cds/lib/srv/protocols/http.js — `get authorize()`):
+//
+//   - @requires on service          → all requests must match a role
+//   - @restrict on service          → 'to' roles across all clauses; if none,
+//                                     falls through to env fallback:
+//                                       prod + restrict_all_services !== false
+//                                         → ['authenticated-user']
+//                                       otherwise → public
+//
+// Both MCP (via checkServiceAccess) and OData (via CAP's HttpAdapter) must
+// enforce these gates identically.
+
+async function mcpRawStatus(path, auth) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream'
+  }
+  if (auth) headers['Authorization'] = `Basic ${Buffer.from(auth).toString('base64')}`
+  const res = await fetch(`${test.url}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })
+  })
+  return res.status
+}
+
+async function odataRootStatus(path, auth) {
+  const headers = { Accept: 'application/json' }
+  if (auth) headers['Authorization'] = `Basic ${Buffer.from(auth).toString('base64')}`
+  const res = await fetch(`${test.url}${path}/Books`, { headers })
+  return res.status
+}
+
+describe('Service-level @requires — @requires: "admin"', () => {
+  const MCP_PATH = '/mcp/service-requires-admin'
+  const ODATA_PATH = '/odata/v4/service-requires-admin'
+
+  it('alice (admin): MCP and OData both grant access', async () => {
+    const [mcp, odata] = await Promise.all([
+      mcpRawStatus(MCP_PATH, 'alice:'),
+      odataRootStatus(ODATA_PATH, 'alice:')
+    ])
+    expect(mcp).to.equal(200)
+    expect(odata).to.equal(200)
+  })
+
+  it('bob (no roles): both surfaces return 403', async () => {
+    const [mcp, odata] = await Promise.all([
+      mcpRawStatus(MCP_PATH, 'bob:'),
+      odataRootStatus(ODATA_PATH, 'bob:')
+    ])
+    expect(mcp).to.equal(403)
+    expect(odata).to.equal(403)
+  })
+
+  it('unauthenticated: both surfaces return 401', async () => {
+    const [mcp, odata] = await Promise.all([
+      mcpRawStatus(MCP_PATH, null),
+      odataRootStatus(ODATA_PATH, null)
+    ])
+    expect(mcp).to.equal(401)
+    expect(odata).to.equal(401)
+  })
+})
+
+describe('Service-level @restrict — @restrict: [{ grant: "READ", to: "admin" }]', () => {
+  const MCP_PATH = '/mcp/service-restrict-admin'
+  const ODATA_PATH = '/odata/v4/service-restrict-admin'
+
+  it('alice (admin): MCP and OData both grant access', async () => {
+    const [mcp, odata] = await Promise.all([
+      mcpRawStatus(MCP_PATH, 'alice:'),
+      odataRootStatus(ODATA_PATH, 'alice:')
+    ])
+    expect(mcp).to.equal(200)
+    expect(odata).to.equal(200)
+  })
+
+  it('bob (no roles): both surfaces return 403', async () => {
+    const [mcp, odata] = await Promise.all([
+      mcpRawStatus(MCP_PATH, 'bob:'),
+      odataRootStatus(ODATA_PATH, 'bob:')
+    ])
+    expect(mcp).to.equal(403)
+    expect(odata).to.equal(403)
+  })
+
+  it('unauthenticated: both surfaces return 401', async () => {
+    const [mcp, odata] = await Promise.all([
+      mcpRawStatus(MCP_PATH, null),
+      odataRootStatus(ODATA_PATH, null)
+    ])
+    expect(mcp).to.equal(401)
+    expect(odata).to.equal(401)
+  })
+})
+
+describe('Service-level @restrict — multiple "to" roles', () => {
+  const MCP_PATH = '/mcp/service-restrict-admin-or-editor'
+  const ODATA_PATH = '/odata/v4/service-restrict-admin-or-editor'
+
+  it('alice (admin): granted', async () => {
+    expect(await mcpRawStatus(MCP_PATH, 'alice:')).to.equal(200)
+    expect(await odataRootStatus(ODATA_PATH, 'alice:')).to.equal(200)
+  })
+
+  it('eve (editor): granted', async () => {
+    expect(await mcpRawStatus(MCP_PATH, 'eve:')).to.equal(200)
+    expect(await odataRootStatus(ODATA_PATH, 'eve:')).to.equal(200)
+  })
+
+  it('bob (no roles): 403', async () => {
+    expect(await mcpRawStatus(MCP_PATH, 'bob:')).to.equal(403)
+    expect(await odataRootStatus(ODATA_PATH, 'bob:')).to.equal(403)
+  })
+
+  it('unauthenticated: 401', async () => {
+    expect(await mcpRawStatus(MCP_PATH, null)).to.equal(401)
+    expect(await odataRootStatus(ODATA_PATH, null)).to.equal(401)
+  })
+})
+
+describe('Service-level @restrict without "to" — env fallback', () => {
+  const MCP_PATH = '/mcp/service-restrict-no-to'
+  const ODATA_PATH = '/odata/v4/service-restrict-no-to'
+
+  describe('dev (NODE_ENV !== "production"): public — everyone including anonymous', () => {
+    // Base config: development. NODE_ENV is not explicitly set to production here.
+    it('alice (admin): 200', async () => {
+      expect(await mcpRawStatus(MCP_PATH, 'alice:')).to.equal(200)
+      expect(await odataRootStatus(ODATA_PATH, 'alice:')).to.equal(200)
+    })
+
+    it('bob (no roles): 200', async () => {
+      expect(await mcpRawStatus(MCP_PATH, 'bob:')).to.equal(200)
+      expect(await odataRootStatus(ODATA_PATH, 'bob:')).to.equal(200)
+    })
+
+    it('unauthenticated: 200 on MCP (OData may still gate via other middleware)', async () => {
+      // MCP has no outer auth middleware — anonymous reaches checkServiceAccess and passes.
+      expect(await mcpRawStatus(MCP_PATH, null)).to.equal(200)
+    })
+  })
+
+  describe('prod (NODE_ENV === "production"): authenticated-user fallback', () => {
+    let savedNodeEnv
+    let savedRestrictAll
+    let restrictAllWasSet
+
+    beforeAll(() => {
+      savedNodeEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      cds.env.requires ??= {}
+      cds.env.requires.auth ??= {}
+      restrictAllWasSet = 'restrict_all_services' in cds.env.requires.auth
+      savedRestrictAll = cds.env.requires.auth.restrict_all_services
+      cds.env.requires.auth.restrict_all_services = true
+    })
+
+    afterAll(() => {
+      if (savedNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = savedNodeEnv
+      if (restrictAllWasSet) cds.env.requires.auth.restrict_all_services = savedRestrictAll
+      else delete cds.env.requires.auth.restrict_all_services
+    })
+
+    it('alice (admin): 200 (authenticated-user is satisfied)', async () => {
+      expect(await mcpRawStatus(MCP_PATH, 'alice:')).to.equal(200)
+    })
+
+    it('bob (no roles): 200 (authenticated-user is satisfied)', async () => {
+      expect(await mcpRawStatus(MCP_PATH, 'bob:')).to.equal(200)
+    })
+
+    it('unauthenticated: 401 on MCP', async () => {
+      expect(await mcpRawStatus(MCP_PATH, null)).to.equal(401)
+    })
+  })
+
+  describe('prod with restrict_all_services=false: public again', () => {
+    let savedNodeEnv
+    let savedRestrictAll
+    let restrictAllWasSet
+
+    beforeAll(() => {
+      savedNodeEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+      cds.env.requires ??= {}
+      cds.env.requires.auth ??= {}
+      restrictAllWasSet = 'restrict_all_services' in cds.env.requires.auth
+      savedRestrictAll = cds.env.requires.auth.restrict_all_services
+      cds.env.requires.auth.restrict_all_services = false
+    })
+
+    afterAll(() => {
+      if (savedNodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = savedNodeEnv
+      if (restrictAllWasSet) cds.env.requires.auth.restrict_all_services = savedRestrictAll
+      else delete cds.env.requires.auth.restrict_all_services
+    })
+
+    it('unauthenticated: 200 on MCP (opt-out disables the prod fallback)', async () => {
+      expect(await mcpRawStatus(MCP_PATH, null)).to.equal(200)
+    })
+  })
+})


### PR DESCRIPTION
Noticed some issues for entity-level require annotations. Only affects the context, actual authorization checks were still working. Here's the summary by claude:
  
1. `@requires` on entities was ignored — per CAP docs, `@requires` is valid on entities (shorthand for `@restrict: [{grant:'*', to: role}]`). Added handling in checkEntityReadAccess.
  2. `@restrict` with no `to` clause used wrong semantics — the old code only admitted authenticated users when `to` was absent. Per docs, omitting `to` means the any pseudo-role → all users including unauthenticated are admitted. Fixed in _matchesToRoles.
  3. `@restrict` on actions was ignored — checkActionAccess only checked `@requires`. Per docs, `@restrict` is also valid on actions (with `grant` implicitly treated as `*`; only `to` is enforced). Added the check.
  4. system-user pseudo-role was unhandled — added explicit handling in _hasRole alongside any and authenticated-user.

  The refactor also extracted _hasRole and _matchesToRoles helpers to eliminate the duplicated role-checking logic that existed across all three check functions.