### PR TITLE
chore: prep v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.4.2 - 2026-08-11
+## Version 1.4.2 - 2026-08-13
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,13 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.4.3 - 2026-08-13
-
-### Fixed
-
-- Entity `@requires` and action `@restrict` annotations are now respected when filtering tool context
-
 ## Version 1.4.2 - 2026-08-11
 
 ### Fixed
 
 - Use `format: cql` as default if the `cds.mcp.format` option is not applied
 - Entities from MCP-enabled services are not shown on index page
+- Entity `@requires` and action `@restrict` annotations are now respected when filtering tool context
 
 ### Removed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/mcp",
-  "version": "1.4.3",
+  "version": "1.4.2",
   "description": "CAP plugin to expose services as MCP servers for AI agent consumption",
   "repository": "cap-js/mcp",
   "files": [


### PR DESCRIPTION
## chore: Prepare release v1.4.2

This PR prepares the `v1.4.2` release by aligning the package version and changelog entries.

### Changes

- **`package.json`**: Reverted version from `1.4.3` back to `1.4.2`
- **`CHANGELOG.md`**: Moved the fix for `@requires`/`@restrict` annotation filtering from the `v1.4.3` entry into the `v1.4.2` entry, consolidating all fixes under the correct release version

### Fixes included in v1.4.2

- Use `format: cql` as default if the `cds.mcp.format` option is not applied
- Entities from MCP-enabled services are not shown on index page
- Entity `@requires` and action `@restrict` annotations are now respected when filtering tool context

**Category:** Chore

### Have you...

- [x] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- Output Template: Repository PR Template
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `f6dcd440-9719-11f1-91de-4e7f12fce710`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
