### PR TITLE
correctly access target name when executing generic read CQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+### Fixed
+
+- Correctly access target name when executing generic read CQL
+
 ## Version 1.4.2 - 2026-08-13
 
 ### Fixed

--- a/lib/tools/query.js
+++ b/lib/tools/query.js
@@ -225,7 +225,7 @@ async function _executeGenericReadCql(srv, entities, args, { log = LOG } = {}) {
   if (!cqn.SELECT) return errorResponse('Error: Only SELECT statements are allowed.')
 
   // Resolve target for LIMIT + expand context
-  const targetName = cqn.SELECT.from?.ref?.[0]
+  const targetName = cqn.SELECT.from?.ref?.[0].id
   const localName =
     targetName && srv.name && targetName.startsWith(srv.name + '.')
       ? targetName.slice(srv.name.length + 1)


### PR DESCRIPTION
### Have you...

- [x] Added relevant entry to the change log?

Addresses #58 

(I ran the tests before and after with `npm run test` and the results were the same)