### PR TITLE
ci: add label-issues workflow

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,18 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: new


### PR DESCRIPTION
Adds the `label-issues` workflow that automatically applies the `new` label to newly opened or reopened issues, so the cap/issues syncer can pick them up.
