### PR TITLE
chore: Update package.json - update license

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "agent"
   ],
   "author": "SAP SE (https://www.sap.com)",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache-2.0",
   "cds": {
     "protocols": {
       "mcp": {


### PR DESCRIPTION
Updated the license property to the corresponding SPDX license ID as per the repository license file and package.json documentation.

According to the documentation, `SEE LICENSE IN <filename>` is to be used when the license does not have an assigned SPDX ID, which is not the case.

References:
* LICENSE file
* https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license

### Have you...

- N/A - Added relevant entry to the change log?
