### PR TITLE
chore: add @cap-js/node-js-runtime to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @cap-js/cdsmunich
-* @cap-js/node-js-runtime
+* @cap-js/cdsmunich @cap-js/node-js-runtime

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @cap-js/cdsmunich
+* @cap-js/node-js-runtime


### PR DESCRIPTION
### Add `@cap-js/node-js-runtime` as CODEOWNER

This change updates the `.github/CODEOWNERS` file to add the `@cap-js/node-js-runtime` team as a code owner, ensuring they are automatically requested for reviews on pull requests.

**Category:** Chore

### Have you...

- [ ] Added relevant entry to the change log?

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.47`

- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `62525ba0-a156-11f1-8b71-0a924761a3e2`
- File Content Strategy: Full file content
</details>
