### PR TITLE
feat: skip describe tool when only actions exposed and `per_action_tool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 1.4.4 - tdb
+
+### Changed
+
+- Skip `describe` tool when `per_action_tool` is enabled and the service exposes only actions/functions (no entities)
+
 ## Version 1.4.3 - 2026-08-14
 
 ### Fixed

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -59,16 +59,19 @@ function generateToolsForService(def, model) {
   }
   const actionNames = Object.keys(actions)
 
-  const describeDef = createDescribeToolDefinition(entityNames, actionNames, def.name, prefix)
-  tools.push({
-    name: describeDef.name,
-    description: describeDef.description,
-    inputSchema: resolveRefsToAbsolutePaths(
-      z.toJSONSchema(describeDef.inputSchema, { target: 'draft-07' }),
-      tools.length
-    ),
-    annotations: describeDef.annotations
-  })
+  // Skip the generic `describe` tool when per-action tools are used and no entities are exposed
+  if (entityNames.length > 0 || !usePerActionTools) {
+    const describeDef = createDescribeToolDefinition(entityNames, actionNames, def.name, prefix)
+    tools.push({
+      name: describeDef.name,
+      description: describeDef.description,
+      inputSchema: resolveRefsToAbsolutePaths(
+        z.toJSONSchema(describeDef.inputSchema, { target: 'draft-07' }),
+        tools.length
+      ),
+      annotations: describeDef.annotations
+    })
+  }
 
   // Add action tools if service has actions/functions
   if (actionNames.length > 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,9 +7,8 @@ const { registerDescribeTool } = require('./tools/describe')
 const { registerGenericReadTool } = require('./tools/query')
 const { registerCallActionTool, registerPerActionTools } = require('./tools/call')
 
-const registerActionTool = cds.env.mcp?.per_action_tool
-  ? registerPerActionTools
-  : registerCallActionTool
+const usePerActionTools = cds.env.mcp?.per_action_tool === true
+const registerActionTool = usePerActionTools ? registerPerActionTools : registerCallActionTool
 const { getDescription } = require('./utils/cds-to-schema')
 const { checkAuthorization } = require('./auth')
 const { resolvePrefix } = require('./utils/service-name')
@@ -78,7 +77,10 @@ module.exports = function McpProtocolAdapter(srv) {
         const entityCount = Object.keys(entities).length
         const actionCount = Object.keys(actions).length
         if (entityCount > 0 || actionCount > 0) {
-          registerDescribeTool(server, srv, entities, actions, prefix)
+          // Skip the generic `describe` tool when per-action tools are used and no entities are exposed
+          if (entityCount > 0 || !usePerActionTools) {
+            registerDescribeTool(server, srv, entities, actions, prefix)
+          }
           registerGenericReadTool(server, srv, entities, prefix)
           registerActionTool(server, srv, actions, prefix)
         } else {

--- a/tests/bookshop/srv/action-only-service.cds
+++ b/tests/bookshop/srv/action-only-service.cds
@@ -1,0 +1,4 @@
+@mcp
+service ActionOnlyService {
+  action myAction(identifier: String) returns String;
+}

--- a/tests/integration/per-action-tools.test.js
+++ b/tests/integration/per-action-tools.test.js
@@ -194,6 +194,17 @@ describe('Per-Action Tools', () => {
       expect(tool.inputSchema.properties).to.have.property('prop1')
       expect(tool.inputSchema.properties.prop1.type).to.equal('string')
     })
+
+    it('should not expose describe tool when no entities are exposed', async () => {
+      // ActionOnlyService only exposes the action 'myAction'
+      const { mcp } = mcpClient('/mcp/action-only')
+      const response = await mcp('tools/list')
+      const toolNames = response.result.tools.map((t) => t.name)
+      expect(toolNames).to.include('myAction')
+      expect(toolNames).not.to.include('describe')
+      expect(toolNames).not.to.include('query')
+      expect(toolNames).not.to.include('call')
+    })
   })
 
   describe('calling per-action tools with complex types', () => {


### PR DESCRIPTION
We should skip the `describe` tool when only actions / functions are exposed in the service and the `per_action_tool` feature flag is set. 