### PR TITLE
fix: prefer entity definition instead of plain string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
-## Version 1.4.4 - tdb
+## Version 1.4.4 - tbd
 
 ### Changed
 

--- a/lib/tools/query.js
+++ b/lib/tools/query.js
@@ -283,7 +283,7 @@ async function _executeGenericReadCqn(srv, entities, args, { log = LOG } = {}) {
   }
 
   // Build CQN
-  let query = SELECT.from(entityName)
+  let query = SELECT.from(srv.entities[entityName] ?? entityName)
 
   if (args.distinct) query.SELECT.distinct = true
 


### PR DESCRIPTION
Follow our own best practices and use entity definition to create the CQN object. 
From  https://github.com/cap-js/mcp-server/issues/134