### PR TITLE
fix: check for existing `from` clause in CQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Version 1.4.4 - 2026-08-21
+
+### Fixed
+
+- `query` tool returns a clear error when a SELECT statement is missing its FROM clause
+
 ## Version 1.4.3 - 2026-08-14
 
 ### Fixed

--- a/lib/tools/query.js
+++ b/lib/tools/query.js
@@ -223,10 +223,15 @@ async function _executeGenericReadCql(srv, entities, args, { log = LOG } = {}) {
   }
 
   if (!cqn.SELECT) return errorResponse('Error: Only SELECT statements are allowed.')
+  if (!cqn.SELECT.from) {
+    return errorResponse(
+      'Error: SELECT statement is missing a FROM clause. Use "SELECT ... FROM <Entity>".'
+    )
+  }
 
   // Resolve target for LIMIT + expand context
   // ref[0] is a string for plain queries or an object { id, where } for queries with infix filters
-  const fromRef = cqn.SELECT.from?.ref?.[0]
+  const fromRef = cqn.SELECT.from.ref?.[0]
   const targetName = typeof fromRef === 'string' ? fromRef : fromRef?.id
   const localName =
     targetName && srv.name && targetName.startsWith(srv.name + '.')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/mcp",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "CAP plugin to expose services as MCP servers for AI agent consumption",
   "repository": "cap-js/mcp",
   "files": [

--- a/tests/integration/sql-format.test.js
+++ b/tests/integration/sql-format.test.js
@@ -86,6 +86,16 @@ describe('SQL Format Mode (cds.env.mcp.format = "cql")', () => {
       expect(error).to.not.be.null
     })
 
+    it('returns clear error when FROM clause is missing', async () => {
+      const { callTool } = mcpClient()
+      const { error } = await callTool('query', {
+        cql: 'SELECT Books'
+      })
+      expect(error).to.not.be.null
+      expect(error).to.match(/missing a FROM clause/i)
+      expect(error).to.not.match(/Cannot read properties of undefined/i)
+    })
+
     it('returns count in result', async () => {
       const { callTool } = mcpClient()
       const { content, error } = await callTool('query', {


### PR DESCRIPTION
Throw an error when `from` is missing instead of undefined
