### PR TITLE
fix: emphasize describe tool for elements before querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Consider the prefix in the `query` tool description
 - `query` tool resolves unqualified entity names in CQL (e.g. `SELECT from User` instead of `SELECT from TsService.User`)
 - `query` tool returns a clear error when a `SELECT` statement is missing its `FROM` clause
+- Updated `query` tool description to more consistently use `describe` for element names
 
 ## Version 1.4.3 - 2026-08-14
 

--- a/lib/tools/query.js
+++ b/lib/tools/query.js
@@ -75,7 +75,8 @@ function createGenericReadToolDefinition(entityNames, serviceName, prefix = '') 
             '- postfix projection syntax, with nested expands, e.g. SELECT from Authors { ID, name, books { ID, title }}, ' +
             '- standard CAP/OData functions and aggregates (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). ' +
             'Database functions (CURRENT_USER, SESSION_USER, SYSUUID, CURRENT_SCHEMA) are not supported. ' +
-            'LIMIT is auto-injected to the service max.'
+            'LIMIT is auto-injected to the service max. ' +
+            `Do not guess element names, ALWAYS use the ${prefix}describe tool. NEVER call this tool in the same message as the describe tool — always wait for describe results before querying.`
         )
     }),
     annotations: {

--- a/lib/utils/service-name.js
+++ b/lib/utils/service-name.js
@@ -1,12 +1,12 @@
 const cds = require('@sap/cds')
 
-const PREFIX = cds.env.mcp?.prefix === true
+const PREFIX = cds.env.mcp?.prefix
 
-exports.resolvePrefix = !PREFIX
-  ? () => ''
-  : PREFIX === true
-    ? (d) => d.name + '-'
-    : (d, prefix) => prefix.replace(/\{service.name\}/, d.name)
+exports.resolvePrefix = (
+  typeof PREFIX === 'string' ? (d) => PREFIX.replace(/\{service.name\}/, d.name) :
+  PREFIX === true ? (d) => d.name + '-' :
+  () => ''
+)
 
 // Replicate CAP's internal _slugified function for service name derivation
 exports.slugified = (name) =>

--- a/lib/utils/service-name.js
+++ b/lib/utils/service-name.js
@@ -2,11 +2,12 @@ const cds = require('@sap/cds')
 
 const PREFIX = cds.env.mcp?.prefix
 
-exports.resolvePrefix = (
-  typeof PREFIX === 'string' ? (d) => PREFIX.replace(/\{service.name\}/, d.name) :
-  PREFIX === true ? (d) => d.name + '-' :
-  () => ''
-)
+exports.resolvePrefix =
+  typeof PREFIX === 'string'
+    ? (d) => PREFIX.replace(/\{service.name\}/, d.name)
+    : PREFIX === true
+      ? (d) => d.name + '-'
+      : () => ''
 
 // Replicate CAP's internal _slugified function for service name derivation
 exports.slugified = (name) =>

--- a/tests/integration/__snapshots__/catalog-service-card.json
+++ b/tests/integration/__snapshots__/catalog-service-card.json
@@ -25,7 +25,7 @@
         "properties": {
           "cql": {
             "type": "string",
-            "description": "CAP CQL statement to execute queries; only SELECT statements are allowed. CQL is a superset of SQL, that supports - path expressions to follow associations instead of JOINs, e.g. SELECT author.name from Books, - postfix projection syntax, with nested expands, e.g. SELECT from Authors { ID, name, books { ID, title }}, - standard CAP/OData functions and aggregates (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). Database functions (CURRENT_USER, SESSION_USER, SYSUUID, CURRENT_SCHEMA) are not supported. LIMIT is auto-injected to the service max."
+            "description": "CAP CQL statement to execute queries; only SELECT statements are allowed. CQL is a superset of SQL, that supports - path expressions to follow associations instead of JOINs, e.g. SELECT author.name from Books, - postfix projection syntax, with nested expands, e.g. SELECT from Authors { ID, name, books { ID, title }}, - standard CAP/OData functions and aggregates (count, sum, avg, min, max, lower, upper, substring, year, month, day, etc.). Database functions (CURRENT_USER, SESSION_USER, SYSUUID, CURRENT_SCHEMA) are not supported. LIMIT is auto-injected to the service max. Do not guess element names, ALWAYS use the describe tool. NEVER call this tool in the same message as the describe tool — always wait for describe results before querying."
           }
         },
         "required": ["cql"],


### PR DESCRIPTION
Before:
<img width="1181" height="1009" alt="Screenshot 2026-09-09 at 14 54 49" src="https://github.com/user-attachments/assets/7266be98-e851-4124-8fc8-f2bc7a2c827e" />

After:
<img width="1181" height="1009" alt="Screenshot 2026-09-09 at 14 55 12" src="https://github.com/user-attachments/assets/0c5acac2-e5b8-4b95-81e4-a84f96800633" />



### Have you...

- [x] Added relevant entry to the change log?
